### PR TITLE
Fix a couple crash bugs I ran into

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -342,7 +342,8 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
                 return false;
         }
 
-        if (side.ordinal() != getTileEntity(world, x, y, z).getDirection())
+	if (getTileEntity(world, x, y, z) == null) return true;
+	if (side.ordinal() != getTileEntity(world, x, y, z).getDirection())
             return true;
 
         return false;

--- a/src/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityController.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityController.java
@@ -208,6 +208,7 @@ public class TileEntityController extends TileEntity implements IDrawerGroup, IS
         TileEntity te = worldObj.getTileEntity(x, y, z);
         if (te == null || !(te instanceof IDrawerGroup))
             return;
+        if (depth > DEPTH_LIMIT) return;
 
         //if (te instanceof TileEntityController && depth < DEPTH_LIMIT) {
         //    populateNeighborNodes(x, y, z, depth + 1);


### PR DESCRIPTION
I ran into a couple odd crash bugs involving one of the wrought iron gates from Garden Stuff next to a drawer causing a NPE, and two drawer controllers next to one another on the x or z axis that were causing stack overflows.