### PR TITLE
Display aspect icons for empty, labeled jars.

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/integration/Thaumcraft.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/integration/Thaumcraft.java
@@ -40,6 +40,7 @@ public class Thaumcraft extends IntegrationModule
         MinecraftForge.EVENT_BUS.register(this);
 
         aspectItems = new Item[] {
+            GameRegistry.findItem(getModID(), "ItemResource"),
             GameRegistry.findItem(getModID(), "ItemEssence"),
             GameRegistry.findItem(getModID(), "ItemWispEssence"),
             GameRegistry.findItem(getModID(), "ItemCrystalEssence"),

--- a/src/com/jaquadro/minecraft/storagedrawers/integration/Thaumcraft.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/integration/Thaumcraft.java
@@ -77,7 +77,12 @@ public class Thaumcraft extends IntegrationModule
         NBTTagCompound tag = itemStack.getTagCompound();
         if (tag == null)
             return;
-
+        
+        if (tag.hasKey("AspectFilter")) {
+	        setDrawerAspectName(drawer, tag.getString("AspectFilter"));
+	        return;
+        }
+        
         NBTTagList tagAspects = tag.getTagList("Aspects", Constants.NBT.TAG_COMPOUND);
         if (tagAspects == null || tagAspects.tagCount() == 0)
             return;
@@ -86,10 +91,13 @@ public class Thaumcraft extends IntegrationModule
         if (tagAspect == null || !tagAspect.hasKey("key"))
             return;
 
-        String key = tagAspect.getString("key");
+        setDrawerAspectName(drawer, tagAspect.getString("key"));
+    }
+    
+    private void setDrawerAspectName (IDrawer drawer, String aspectName) {
         AspectList allAspects = ThaumcraftApiHelper.getAllAspects(1);
         for (Aspect a : allAspects.aspects.keySet()) {
-            if (a.getTag().equals(key)) {
+            if (a.getTag().equals(aspectName)) {
                 drawer.setExtendedData("aspect", a);
                 return;
             }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/307683/7665307/26938348-fb4d-11e4-80a0-c68a21b75542.png)

This has the additional perk of displaying the aspect name for these jars in the WAILA tooltip.

For the sake of completion, the second commit makes aspect icons appear for aspected jar labels that are not on a jar.

Fixes #83
