### PR TITLE
Fixed crash on dedicated server

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -679,6 +679,7 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
         loadBlockConfig();
     }
 
+    @SideOnly(Side.CLIENT)
     private void loadBlockConfig () {
         try {
             IResource configResource = Minecraft.getMinecraft().getResourceManager().getResource(blockConfig);


### PR DESCRIPTION
http://pastebin.com/BaPYQ4Gk

Possibly due to other class loading behaviour with Java 8. Not exactly sure. This should fix it anyway.