### PR TITLE
Implement Sorting Trim. (Refined Relocation Compat)

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/integration/RefinedRelocation.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/integration/RefinedRelocation.java
@@ -24,6 +24,7 @@ public class RefinedRelocation extends IntegrationModule
     public static BlockSortingDrawers halfDrawers2;
     public static BlockSortingDrawers halfDrawers4;
     public static BlockSortingCompDrawers compDrawers;
+    public static BlockSortingTrim trim;
 
     public static ItemUpgradeSorting upgradeSorting;
 
@@ -53,6 +54,7 @@ public class RefinedRelocation extends IntegrationModule
         halfDrawers2 = new BlockSortingDrawers("halfDrawers2", 2, true);
         halfDrawers4 = new BlockSortingDrawers("halfDrawers4", 4, true);
         compDrawers = new BlockSortingCompDrawers("compDrawers");
+        trim = new BlockSortingTrim("trim");
 
         upgradeSorting = new ItemUpgradeSorting("upgradeSorting");
 
@@ -62,6 +64,7 @@ public class RefinedRelocation extends IntegrationModule
         SortingBlockRegistry.register(ModBlocks.halfDrawers2, halfDrawers2);
         SortingBlockRegistry.register(ModBlocks.halfDrawers4, halfDrawers4);
         SortingBlockRegistry.register(ModBlocks.compDrawers, compDrawers);
+        SortingBlockRegistry.register(ModBlocks.trim, trim);
 
         ConfigManager config = StorageDrawers.config;
 
@@ -77,6 +80,8 @@ public class RefinedRelocation extends IntegrationModule
             GameRegistry.registerBlock(halfDrawers4, ItemSortingDrawers.class, "halfDrawersSort4");
         if (config.isBlockEnabled("compdrawers"))
             GameRegistry.registerBlock(compDrawers, ItemSortingCompDrawers.class, "compDrawersSort");
+        if (config.isBlockEnabled("trim"))
+            GameRegistry.registerBlock(trim, ItemSortingTrim.class, "trimSort");
 
         if (config.cache.enableSortingUpgrades)
             GameRegistry.registerItem(upgradeSorting, "upgradeSorting");
@@ -89,11 +94,13 @@ public class RefinedRelocation extends IntegrationModule
         StorageDrawers.proxy.registerDrawer(compDrawers);
 
         GameRegistry.registerTileEntityWithAlternatives(TileSortingDrawersStandard.class, ModBlocks.getQualifiedName("tileSortingDrawersStandard"),
-            ModBlocks.getQualifiedName(fullDrawers1), ModBlocks.getQualifiedName(fullDrawers2), ModBlocks.getQualifiedName(fullDrawers4),
-            ModBlocks.getQualifiedName(halfDrawers2), ModBlocks.getQualifiedName(halfDrawers4));
+                ModBlocks.getQualifiedName(fullDrawers1), ModBlocks.getQualifiedName(fullDrawers2), ModBlocks.getQualifiedName(fullDrawers4),
+                ModBlocks.getQualifiedName(halfDrawers2), ModBlocks.getQualifiedName(halfDrawers4));
 
         GameRegistry.registerTileEntityWithAlternatives(TileSortingDrawersComp.class, ModBlocks.getQualifiedName("tileSortingDrawersComp"),
             ModBlocks.getQualifiedName(compDrawers));
+
+        GameRegistry.registerTileEntityWithAlternatives(TileSortingTrim.class, ModBlocks.getQualifiedName("tileSortingTrim"), ModBlocks.getQualifiedName(trim));
     }
 
     @Override
@@ -116,6 +123,8 @@ public class RefinedRelocation extends IntegrationModule
             if (config.isBlockEnabled("halfdrawers4"))
                 GameRegistry.addRecipe(new ItemStack(halfDrawers4, 1, i), "x x", " y ", "x x",
                     'x', Items.gold_nugget, 'y', new ItemStack(ModBlocks.halfDrawers4, 1, i));
+            if (config.isBlockEnabled("trim"))
+                GameRegistry.addRecipe(new ItemStack(trim, 1, i), "x x", " y ", "x x", 'x', Items.gold_nugget, 'y', new ItemStack(ModBlocks.trim, 1, i));
         }
 
         if (config.isBlockEnabled("compdrawers"))

--- a/src/com/jaquadro/minecraft/storagedrawers/integration/refinedrelocation/BlockSortingTrim.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/integration/refinedrelocation/BlockSortingTrim.java
@@ -1,0 +1,62 @@
+package com.jaquadro.minecraft.storagedrawers.integration.refinedrelocation;
+
+import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.BlockTrim;
+import com.jaquadro.minecraft.storagedrawers.integration.RefinedRelocation;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockWood;
+import net.minecraft.block.ITileEntityProvider;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
+
+public class BlockSortingTrim extends BlockTrim implements ITileEntityProvider
+{
+    @SideOnly(Side.CLIENT)
+    protected IIcon[] iconSort;
+
+    public BlockSortingTrim (String name) {
+        super(name);
+        setCreativeTab(RefinedRelocation.tabStorageDrawers);
+    }
+
+    @Override
+    public TileEntity createNewTileEntity(World world, int metadata) {
+        return new TileSortingTrim();
+    }
+
+    @Override
+    public IIcon getIcon (int side, int meta) {
+        if (side == 1)
+            return iconSort[meta];
+
+        return super.getIcon(side, meta);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void registerBlockIcons (IIconRegister register) {
+        super.registerBlockIcons(register);
+
+        String[] subtex = BlockWood.field_150096_a;
+
+        iconSort = new IIcon[subtex.length];
+
+        for (int i = 0; i < subtex.length; i++) {
+            iconSort[i] = register.registerIcon(StorageDrawers.MOD_ID + ":drawers_" + subtex[i] + "_sort");
+        }
+    }
+
+    public static boolean upgradeToSorting(World world, int x, int y, int z) {
+        Block block = world.getBlock(x, y, z);
+        int meta = world.getBlockMetadata(x, y, z);
+        Block sortingBlock = SortingBlockRegistry.resolveSortingBlock(block);
+        if (sortingBlock != null) {
+            world.setBlock(x, y, z, sortingBlock, meta, 3);
+        }
+        return true;
+    }
+}

--- a/src/com/jaquadro/minecraft/storagedrawers/integration/refinedrelocation/ItemSortingTrim.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/integration/refinedrelocation/ItemSortingTrim.java
@@ -1,0 +1,28 @@
+package com.jaquadro.minecraft.storagedrawers.integration.refinedrelocation;
+
+import com.jaquadro.minecraft.storagedrawers.item.ItemTrim;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
+
+import java.util.List;
+
+public class ItemSortingTrim extends ItemTrim
+{
+    public ItemSortingTrim(Block block) {
+        super(block);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void addInformation (ItemStack itemStack, EntityPlayer player, List list, boolean par4) {
+        super.addInformation(itemStack, player, list, par4);
+
+        Block block = Block.getBlockFromItem(itemStack.getItem());
+        list.add(EnumChatFormatting.YELLOW + StatCollector.translateToLocalFormatted("storageDrawers.waila.sorting"));
+    }
+}

--- a/src/com/jaquadro/minecraft/storagedrawers/integration/refinedrelocation/ItemUpgradeSorting.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/integration/refinedrelocation/ItemUpgradeSorting.java
@@ -3,7 +3,9 @@ package com.jaquadro.minecraft.storagedrawers.integration.refinedrelocation;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard;
+import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
 import com.jaquadro.minecraft.storagedrawers.core.ModCreativeTabs;
+import com.jaquadro.minecraft.storagedrawers.integration.RefinedRelocation;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -39,6 +41,13 @@ public class ItemUpgradeSorting extends Item
     public boolean onItemUseFirst (ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ) {
         if (world.isRemote)
             return false;
+
+        if(world.getBlock(x, y, z) == ModBlocks.trim) {
+            if(BlockSortingTrim.upgradeToSorting(world, x, y, z)) {
+                stack.stackSize--;
+                return true;
+            }
+        }
 
         TileEntity tile = world.getTileEntity(x, y, z);
         if (tile == null)

--- a/src/com/jaquadro/minecraft/storagedrawers/integration/refinedrelocation/TileSortingTrim.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/integration/refinedrelocation/TileSortingTrim.java
@@ -1,0 +1,39 @@
+package com.jaquadro.minecraft.storagedrawers.integration.refinedrelocation;
+
+import com.dynious.refinedrelocation.api.APIUtils;
+import com.dynious.refinedrelocation.api.tileentity.ISortingMember;
+import com.dynious.refinedrelocation.api.tileentity.handlers.ISortingMemberHandler;
+import net.minecraft.tileentity.TileEntity;
+
+public class TileSortingTrim extends TileEntity implements ISortingMember {
+
+    private ISortingMemberHandler sortingHandler = APIUtils.createSortingMemberHandler(this);
+    private boolean isFirstTick = true;
+
+    @Override
+    public ISortingMemberHandler getHandler() {
+        return sortingHandler;
+    }
+
+    @Override
+    public void updateEntity() {
+        if(isFirstTick) {
+            sortingHandler.onTileAdded();
+            isFirstTick = false;
+        }
+        super.updateEntity();
+    }
+
+    @Override
+    public void invalidate() {
+        sortingHandler.onTileRemoved();
+        super.invalidate();
+    }
+
+    @Override
+    public void onChunkUnload() {
+        sortingHandler.onTileRemoved();
+        super.onChunkUnload();
+    }
+
+}


### PR DESCRIPTION
The sorting trim version connects Refined Relocation sorting networks with each other the same way Sorting Connectors do, while also providing the trim functionality. See https://github.com/Dynious/RefinedRelocation/issues/322