### PR TITLE
Fix jaquadro/StorageDrawers#163

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
@@ -67,6 +67,7 @@ public interface IDrawer
      * Stack size and available capacity are not considered.  For drawers that are not empty, this
      * method can allow ore-dictionary compatible items to be accepted into the drawer, as defined by what
      * the drawer considers to be an equivalent item.
+     * For drawers that are empty, locking status is considered.
      *
      * @param itemPrototype An ItemStack representing the type, metadata, and tags of an item.
      */

--- a/src/com/jaquadro/minecraft/storagedrawers/storage/CompDrawerData.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/storage/CompDrawerData.java
@@ -71,8 +71,8 @@ public class CompDrawerData extends BaseDrawerData implements IFractionalDrawer,
 
     @Override
     public boolean canItemBeStored (ItemStack itemPrototype) {
-        if (getStoredItemPrototype() == null)
-            return true;
+        if (getStoredItemPrototype() == null && !isLocked(LockAttribute.LOCK_POPULATED))
+        	return true;
 
         return areItemsEqual(itemPrototype);
     }

--- a/src/com/jaquadro/minecraft/storagedrawers/storage/CompDrawerData.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/storage/CompDrawerData.java
@@ -72,7 +72,7 @@ public class CompDrawerData extends BaseDrawerData implements IFractionalDrawer,
     @Override
     public boolean canItemBeStored (ItemStack itemPrototype) {
         if (getStoredItemPrototype() == null && !isLocked(LockAttribute.LOCK_POPULATED))
-        	return true;
+            return true;
 
         return areItemsEqual(itemPrototype);
     }

--- a/src/com/jaquadro/minecraft/storagedrawers/storage/DrawerData.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/storage/DrawerData.java
@@ -135,7 +135,7 @@ public class DrawerData extends BaseDrawerData implements IVoidable, IShroudable
 
     @Override
     public boolean canItemBeStored (ItemStack itemPrototype) {
-        if (protoStack == nullStack)
+        if (protoStack == nullStack && !isLocked(LockAttribute.LOCK_POPULATED))
             return true;
 
         return areItemsEqual(itemPrototype);


### PR DESCRIPTION
Changes the API to reject items inserted into empty drawers that are locked to nothing.  (not locked to a specific item)

so this should solve @rmb938's complaint in RS485/LogisticsPipes/pull/839 as well.