### PR TITLE
Add drawer packs as Gradle multi-project dependencies

### DIFF
--- a/packs/BiomesOPlenty/build.gradle
+++ b/packs/BiomesOPlenty/build.gradle
@@ -39,7 +39,7 @@ sourceSets.main {
 }
 
 dependencies {
-
+    compile project(path: ':', transitive: false)
 }
 
 processResources

--- a/packs/Erebus/build.gradle
+++ b/packs/Erebus/build.gradle
@@ -39,7 +39,7 @@ sourceSets.main {
 }
 
 dependencies {
-
+    compile project(path: ':', transitive: false)
 }
 
 processResources

--- a/packs/Forestry/build.gradle
+++ b/packs/Forestry/build.gradle
@@ -39,7 +39,7 @@ sourceSets.main {
 }
 
 dependencies {
-
+    compile project(path: ':', transitive: false)
 }
 
 processResources

--- a/packs/Misc/build.gradle
+++ b/packs/Misc/build.gradle
@@ -39,7 +39,7 @@ sourceSets.main {
 }
 
 dependencies {
-
+    compile project(path: ':', transitive: false)
 }
 
 processResources

--- a/packs/Natura/build.gradle
+++ b/packs/Natura/build.gradle
@@ -39,7 +39,7 @@ sourceSets.main {
 }
 
 dependencies {
-
+    compile project(path: ':', transitive: false)
 }
 
 processResources

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+include 'packs/BiomesOPlenty', 'packs/Erebus', 'packs/Forestry', 'packs/Misc', 'packs/Natura'


### PR DESCRIPTION
Ref: https://docs.gradle.org/current/userguide/multi_project_builds.html

This patch registers the pack projects as subprojects of the root StorageDrawers project, and then declares that the subprojects depend on the root project. The dependency causes StorageDrawers to be built before any packs, and also adds the StorageDrawers libs folder to the classpath when building the packs.

When you run `gradle build`, it will build StorageDrawers and all drawer packs. To build only StorageDrawers, you must run `gradle :build` instead. Alternately, run `gradle :packs/Erebus:build` to build only the Erebus pack. To skip building StorageDrawers if it is already built, `gradle -a :packs/Erebus:build` will build only the Erebus pack without rebuilding StorageDrawers.

The pack jars are still scattered into the `packs/<name>/build/libs` folders. There's probably a way to copy them all into `build/libs` but I didn't look into it too closely. There's probably a way to add the dependency for every pack using the root `build.gradle` instead of in each pack's file but I didn't look too closely at that, either.
