### PR TITLE
Restore Thaumcraft Integration to its former glory

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/integration/Thaumcraft.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/integration/Thaumcraft.java
@@ -23,7 +23,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import org.lwjgl.opengl.GL11;
 import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectHelper;
+import thaumcraft.api.aspects.IEssentiaContainerItem;
 import thaumcraft.api.aspects.AspectList;
 
 public class Thaumcraft extends IntegrationModule
@@ -74,11 +74,13 @@ public class Thaumcraft extends IntegrationModule
     }
 
     private void setDrawerAspect (IDrawer drawer, ItemStack itemStack) {
-        AspectList aspects = AspectHelper.getObjectAspects(itemStack);
-        if (aspects == null || aspects.size() == 0)
-            return;
-
-        drawer.setExtendedData("aspect", aspects.getAspects()[0]);
+        if(itemStack.getItem() instanceof IEssentiaContainerItem) {
+            IEssentiaContainerItem container = (IEssentiaContainerItem)itemStack.getItem();
+            AspectList aspects = container.getAspects(itemStack);
+            if (!(aspects == null || aspects.size() == 0)) {
+                drawer.setExtendedData("aspect", aspects.getAspects()[0]);
+            }
+        }
     }
 
     private class WailaTooltipHandler implements IWailaTooltipHandler {

--- a/src/com/jaquadro/minecraft/storagedrawers/integration/Thaumcraft.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/integration/Thaumcraft.java
@@ -44,6 +44,7 @@ public class Thaumcraft extends IntegrationModule
             GameRegistry.findItem(getModID(), "wispy_essence"),
             GameRegistry.findItem(getModID(), "crystal_essence"),
             GameRegistry.findItem(getModID(), "jar"),
+            GameRegistry.findItem(getModID(), "label"),
         };
 
         StorageDrawersApi.instance().renderRegistry().registerPreLabelRenderHandler(new LabelRenderHandler());

--- a/src/com/jaquadro/minecraft/storagedrawers/integration/Thaumcraft.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/integration/Thaumcraft.java
@@ -15,6 +15,7 @@ import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.ResourceLocation;
@@ -74,6 +75,19 @@ public class Thaumcraft extends IntegrationModule
     }
 
     private void setDrawerAspect (IDrawer drawer, ItemStack itemStack) {
+        /* Check for labeled jars first */
+        NBTTagCompound compound = itemStack.getTagCompound();
+        if (compound != null) {
+            if (compound.hasKey("AspectFilter")) {
+                String aspectFilter = compound.getString("AspectFilter");
+                Aspect aspect = Aspect.getAspect(aspectFilter);
+                if (aspect != null) {
+                    drawer.setExtendedData("aspect", aspect);
+                    return;
+                }
+            }
+        }
+        /* Otherwise, see if the item contains essentia */
         if(itemStack.getItem() instanceof IEssentiaContainerItem) {
             IEssentiaContainerItem container = (IEssentiaContainerItem)itemStack.getItem();
             AspectList aspects = container.getAspects(itemStack);


### PR DESCRIPTION
Wow, déjà vu, right? These changes do the following:
- Display the aspect for marked jar labels
- Display the correct aspect for empty, labeled jars
- Display no aspect for empty essentia phials
- Display no aspect for empty, non-labeled jars

The method for asking Thaumcraft about aspects is changed. Instead of calling `AspectHelper.getObjectAspects()` (which asks Thaumcraft what aspects are yielded when the object is melted down to essentia), we check if the item is an instance of [`IEssentiaContainerItem`](https://github.com/Azanor/thaumcraft-5-api/blob/master/aspects/IEssentiaContainerItem.java) instead, and call `IEssentiaContainerItem.getAspects()` to get the aspects contained by the item _without_ the aspects inherent to the container itself. 

Notably, a marked jar label "contains" one of its aspect without yielding that aspect when melted, and an empty jar or phial contains zero aspects, yet it yields one Aqua or Vacuous respectively when melted (causing the empties to incorrectly display that aspect on the drawer).

![image](https://cloud.githubusercontent.com/assets/307683/14041257/22a21dd6-f213-11e5-9cc9-f80c4dc5e314.png)

(The drawer on the right is just a sanity check, you can ignore that.)

Fixes #249 
