### PR TITLE
Fix fallback shaped ore recipe sorting priority

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/core/ModRecipes.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/core/ModRecipes.java
@@ -19,7 +19,7 @@ public class ModRecipes
     public void init () {
         OreDictionary.registerOre("chestWood", new ItemStack(Blocks.chest)); // Remove when porting to 1.8
 
-        RecipeSorter.register("StorageDrawers:FallbackShapedOreRecipe", FallbackShapedOreRecipe.class, RecipeSorter.Category.SHAPED, "after:minecraft:shapedore");
+        RecipeSorter.register("StorageDrawers:FallbackShapedOreRecipe", FallbackShapedOreRecipe.class, RecipeSorter.Category.SHAPED, "after:forge:shapedore");
         
         ConfigManager config = StorageDrawers.config;
 


### PR DESCRIPTION
I heard you weren't updating for 1.7.10 any more, but I didn't see any place to do an equivalent patch for the newer versions, so here you go!

xref: [Forge RecipeSorter](https://github.com/MinecraftForge/MinecraftForge/blob/1.7.10/src/main/java/net/minecraftforge/oredict/RecipeSorter.java#L115)

Fixes #214
