### PR TITLE
Don't redraw Compacting Drawers on each insert/extract

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersComp.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersComp.java
@@ -166,8 +166,6 @@ public class TileEntityDrawersComp extends TileEntityDrawers
     public void clientUpdateCount (int slot, int count) {
         if (count != pooledCount) {
             pooledCount = count;
-            IBlockState state = getWorld().getBlockState(getPos());
-            getWorld().notifyBlockUpdate(getPos(), state, state, 3);
         }
     }
 


### PR DESCRIPTION
Noticed this while playing the new SkyFactory and compressing gravel.

viz. c347e4a91aacbf6d10895258e50837ae0b633f38 👌

The drawer will still redraw when it is completely emptied and when a different item is inserted.