### PR TITLE
Fix a render glitch when a drawer is near a Botania floating flower

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
@@ -266,6 +266,7 @@ public class TileEntityDrawersRenderer extends TileEntitySpecialRenderer<TileEnt
 
         renderItem.renderItemIntoGUI(itemStack, 0, 0);
         GlStateManager.disableBlend(); // Clean up after RenderItem
+        GlStateManager.enableAlpha();  // Restore world render state after RenderItem
 
         GlStateManager.disablePolygonOffset();
 


### PR DESCRIPTION
Follow-up to #394

![image](https://cloud.githubusercontent.com/assets/307683/23344480/432f893a-fc21-11e6-832f-e8fe0362a7ea.png)

RenderItem only expects to be called in the context of GUIs, where alpha testing is not always on. But when called in the context of world rendering, alpha testing being on is the base state. So we just turn it back on after RenderItem turns it off.