### PR TITLE
Localization fix for drawer controller

### DIFF
--- a/resources/assets/storagedrawers/lang/de_de.lang
+++ b/resources/assets/storagedrawers/lang/de_de.lang
@@ -4,13 +4,13 @@ itemGroup.storagedrawersSorting=Storage Drawers - Sortieren
 storagedrawers.container.drawers=Schubfächer
 storagedrawers.container.compDrawers=Verdichtende Schubfächer
 storagedrawers.container.upgrades=Upgrades
-storagedrawers.container.controller=Schubfach-Controller
+storagedrawers.container.drawer_controller=Schubfach-Controller
 storagedrawers.container.unboundSlave=Uneingebundener Slave
 storagedrawers.container.framingTable=Rahmen-Werkbank
 
 storagedrawers.msg.maxUpgrades=Dieses Schubfach kann keine Upgrades mehr aufnehmen.
 storagedrawers.msg.cannotAddUpgrade=Dieses Update kann in dem Schubfach nicht installiert werden.
- 
+
 # Items
 item.storagedrawers.upgradeTemplate.name=Upgradeschablone
 item.storagedrawers.upgradeStorage.obsidian.name=Speicher-Upgrade (I)

--- a/resources/assets/storagedrawers/lang/en_us.lang
+++ b/resources/assets/storagedrawers/lang/en_us.lang
@@ -6,7 +6,7 @@ itemGroup.storagedrawersSorting=Storage Drawers - Sorting
 storagedrawers.container.drawers=Drawers
 storagedrawers.container.compDrawers=Compacting Drawers
 storagedrawers.container.upgrades=Upgrades
-storagedrawers.container.controller=Drawer Controller
+storagedrawers.container.drawer_controller=Drawer Controller
 storagedrawers.container.unboundSlave=Unbound Slave
 storagedrawers.container.framingTable=Framing Table
 

--- a/resources/assets/storagedrawers/lang/fr_fr.lang
+++ b/resources/assets/storagedrawers/lang/fr_fr.lang
@@ -4,7 +4,7 @@ itemGroup.storagedrawersSorting=Storage Drawers - Tri
 storagedrawers.container.drawers=Tiroirs
 storagedrawers.container.compDrawers=Tiroirs de compactage
 storagedrawers.container.upgrades=Améliorations
-storagedrawers.container.controller=Contrôleur de tiroirs
+storagedrawers.container.drawer_controller=Contrôleur de tiroirs
 storagedrawers.container.unboundSlave=Esclave non lié
 storagedrawers.container.framingTable=Table de fabrication de tiroirs
 

--- a/resources/assets/storagedrawers/lang/ja_jp.lang
+++ b/resources/assets/storagedrawers/lang/ja_jp.lang
@@ -4,7 +4,7 @@ itemGroup.storagedrawersSorting=収納ひきだし - ソート
 storagedrawers.container.drawers=ひきだし
 storagedrawers.container.compDrawers=変換ひきだし
 storagedrawers.container.upgrades=アップグレード
-storagedrawers.container.controller=ひきだしコントローラ
+storagedrawers.container.drawer_controller=ひきだしコントローラ
 storagedrawers.container.unboundSlave=孤立している
 storagedrawers.container.framingTable=組み立て台
 

--- a/resources/assets/storagedrawers/lang/ru_ru.lang
+++ b/resources/assets/storagedrawers/lang/ru_ru.lang
@@ -4,7 +4,7 @@ itemGroup.storagedrawersSorting=Storage Drawers - Сортировка
 storagedrawers.container.drawers=Ящики
 storagedrawers.container.compDrawers=Уплотняющие Ящики
 storagedrawers.container.upgrades=Улучшения
-storagedrawers.container.controller=Контроллер Ящика
+storagedrawers.container.drawer_controller=Контроллер Ящика
 storagedrawers.container.unboundSlave=Непривязанный Подчинённый
 storagedrawers.container.framingTable=Стол Обрамления
 

--- a/resources/assets/storagedrawers/lang/zh_cn.lang
+++ b/resources/assets/storagedrawers/lang/zh_cn.lang
@@ -7,7 +7,7 @@ itemGroup.storagedrawersSorting=储物抽屉|分拣升级
 storagedrawers.container.drawers=抽屉
 storagedrawers.container.compDrawers=压缩抽屉
 storagedrawers.container.upgrades=升级组件
-storagedrawers.container.controller=抽屉管理器
+storagedrawers.container.drawer_controller=抽屉管理器
 storagedrawers.container.unboundSlave=未连接的传动方块
 storagedrawers.container.framingTable=成型台
 

--- a/resources/assets/storagedrawers/lang/zh_tw.lang
+++ b/resources/assets/storagedrawers/lang/zh_tw.lang
@@ -4,7 +4,7 @@ itemGroup.storagedrawersSorting=儲物抽屜|整理
 storagedrawers.container.drawers=抽屜
 storagedrawers.container.compDrawers=壓縮抽屜
 storagedrawers.container.upgrades=升級組件
-storagedrawers.container.controller=抽屜管理器
+storagedrawers.container.drawer_controller=抽屜管理器
 storagedrawers.container.unboundSlave=未連接的傳動方塊
 
 storagedrawers.msg.maxUpgrades=這個抽屜已無法接受更多的升級。

--- a/src/com/jaquadro/minecraft/storagedrawers/block/BlockController.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/block/BlockController.java
@@ -36,7 +36,7 @@ public class BlockController extends BlockContainer implements INetworked
     public BlockController (String name) {
         super(Material.ROCK);
 
-        setUnlocalizedName(name);
+        setUnlocalizedName("drawer_controller");
         setRegistryName(name);
         this.useNeighborBrightness = true;
 


### PR DESCRIPTION
Right now, the drawer controller has its localization key as `tile.controller.name`, which is nice in isolation, but if any other mods (like my mod, Better Boilers) decide to use the same localization key, that causes some conflict. I've patched this up [on my end](https://github.com/elytra/BetterBoilers/issues/5), and I thought I'd send a PR for a small localization fix your way. This is just the UnlocalizedName so it won't cause any refactor; it'll just fix the collision issue. Hopefully in the future localization will be namespaced so this problem won't exist.