### PR TITLE
Fix: added simulation check before setStoredItem

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityController.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityController.java
@@ -725,7 +725,7 @@ public class TileEntityController extends TileEntity implements IDrawerGroup
                 if (simulate && checkedSlots.contains(slot))
                     continue;
 
-                if (drawer.isEmpty())
+                if (drawer.isEmpty() && !simulate)
                     drawer = drawer.setStoredItem(stack);
 
                 amount = (simulate)


### PR DESCRIPTION
#616 : This fixes the controller creating itemstacks in empty drawers with a stacksize of 0.

This issue mainly occurs when you try to pipe items in the controller from an inventory where the itemstack cannot be extracted.