### PR TITLE
Fix duplicate recipes in NEI

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/integration/notenoughitems/UpgradeItemRecipeHandler.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/integration/notenoughitems/UpgradeItemRecipeHandler.java
@@ -28,6 +28,5 @@ public class UpgradeItemRecipeHandler extends ShapedRecipeHandler
                 sticks, sticks, sticks
             }, result));
         }
-        super.loadCraftingRecipes(result);
     }
 }


### PR DESCRIPTION
The recipe handler currently re-registers every regular crafting recipe for NEI, causing all recipes to be shown twice. Removing the super call fixes that.