### PR TITLE
Fix large extractions on small stored item counts returning incorrect stacks

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
@@ -68,7 +68,7 @@ public interface IDrawer
             int stored = getStoredItemCount();
             int destroy = Math.min(Math.abs(amount), getStoredItemCount());
             setStoredItemCount(stored - destroy);
-            return amount + destroy;
+            return Math.abs(amount + destroy);
         } else {
             return 0;
         }


### PR DESCRIPTION
Or, "Change `adjustStoredItemCount` to match documentation"

On a casual read-through I noticed this function can return a negative number even though its docs say otherwise. The callers of this function seem to expect it will only return a positive remainder, notably in `extractItem` where its result is subtracted from the amount requested for extraction. Subtracting the negative result would lead `extractItem` to return a *larger* stack than what is requested, whenever the amount requested is larger than the amount stored in the drawer.