### PR TITLE
Fix #664 - Locked drawers appear to lose reservations

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/inventory/ItemStackHelper.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/inventory/ItemStackHelper.java
@@ -4,6 +4,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.capabilities.CapabilityDispatcher;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
 import javax.annotation.Nonnull;
 import java.lang.reflect.Field;
@@ -123,10 +124,10 @@ public class ItemStackHelper
 
     static {
         try {
-            itemField = ItemStack.class.getDeclaredField("item");
-            itemDamageField = ItemStack.class.getDeclaredField("itemDamage");
-            stackTagCompoundField = ItemStack.class.getDeclaredField("stackTagCompound");
-            capabilitiesField = ItemStack.class.getDeclaredField("capabilities");
+            itemField = ReflectionHelper.findField(ItemStack.class,  "item", "field_151002_e");
+            itemDamageField = ReflectionHelper.findField(ItemStack.class,"itemDamage", "field_77991_e");
+            stackTagCompoundField = ReflectionHelper.findField(ItemStack.class,"stackTagCompound", "field_77990_d");
+            capabilitiesField = ReflectionHelper.findField(ItemStack.class,"capabilities");
 
             itemField.setAccessible(true);
             itemDamageField.setAccessible(true);
@@ -134,7 +135,7 @@ public class ItemStackHelper
             capabilitiesField.setAccessible(true);
 
             initialized = true;
-        } catch (NoSuchFieldException e) {
+        } catch (ReflectionHelper.UnableToFindFieldException e) {
             initialized = false;
         }
     }


### PR DESCRIPTION
Issue is caused by reflection access to ItemStack fields not using the obfuscated field names, which leads to a failure to access the "true" item of any zero-count itemstack used by the drawer GUI, instead treating it as an empty itemstack.