### PR TITLE
Add a null check for players on BlockDrawers.isReplaceable

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ minecraft_base_version=1.15
 minecraft_version=1.15.2
 forge_version=1.15.2-31.1.14
 forge_mappings=20200215-1.15.1
-mod_version=7.0.2
+mod_version=7.0.3
 
 jei_version=6.0.0.11
 hwyla_version=1.10.5-B66_1.14.4

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -232,7 +232,7 @@ public abstract class BlockDrawers extends HorizontalBlock implements INetworked
 
     @Override
     public boolean isReplaceable (BlockState state, BlockItemUseContext useContext) {
-        if (useContext.getPlayer().isCreative() && useContext.getHand() == Hand.OFF_HAND) {
+        if (useContext.getPlayer() != null && useContext.getPlayer().isCreative() && useContext.getHand() == Hand.OFF_HAND) {
             double blockReachDistance = useContext.getPlayer().getAttribute(PlayerEntity.REACH_DISTANCE).getValue() + 1;
             BlockRayTraceResult result = rayTraceEyes(useContext.getWorld(), useContext.getPlayer(), blockReachDistance);
 


### PR DESCRIPTION
This is to address #820

I assume the mod_version is semantic, but I can yank that out if desired.