### PR TITLE
Forward-port empty-locked-drawer fix from 1.14 to 1.15

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
@@ -60,12 +60,13 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
 
     private long lastClickTime;
     private UUID lastClickUUID;
+    private boolean loading;
 
     private class DrawerAttributes extends BasicDrawerAttributes
     {
         @Override
         protected void onAttributeChanged () {
-            if (!TileEntityDrawers.this.drawerAttributes.isItemLocked(LockAttribute.LOCK_POPULATED)) {
+            if (!loading && !TileEntityDrawers.this.drawerAttributes.isItemLocked(LockAttribute.LOCK_POPULATED)) {
                 for (int slot = 0; slot < TileEntityDrawers.this.getGroup().getDrawerCount(); slot++) {
                     if (TileEntityDrawers.this.emptySlotCanBeCleared(slot)) {
                         IDrawer drawer = TileEntityDrawers.this.getGroup().getDrawer(slot);
@@ -459,6 +460,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
 
     @Override
     public void readPortable (CompoundNBT tag) {
+        loading = true;
         super.readPortable(tag);
 
         //material = null;
@@ -494,6 +496,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
         securityKey = null;
         if (tag.hasKey("Sec"))
             securityKey = tag.getString("Sec");*/
+        loading = false;
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
@@ -590,6 +590,9 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
         @Nonnull
         @Override
         public IDrawer setStoredItem (@Nonnull ItemStack itemPrototype) {
+            if (ItemStackHelper.isStackEncoded(itemPrototype))
+                itemPrototype = ItemStackHelper.decodeItemStackPrototype(itemPrototype);
+
             return storage.setStoredItem(slot, itemPrototype);
         }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/StandardDrawerGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/StandardDrawerGroup.java
@@ -181,9 +181,11 @@ public abstract class StandardDrawerGroup extends TileDataShim implements IDrawe
         }
 
         protected IDrawer setStoredItem (@Nonnull ItemStack itemPrototype, boolean notify) {
-            if (matcher.matches(itemPrototype)) {
+            if (ItemStackHelper.isStackEncoded(itemPrototype))
+                itemPrototype = ItemStackHelper.decodeItemStackPrototype(itemPrototype);
+
+            if (matcher.matches(itemPrototype))
                 return this;
-            }
 
             itemPrototype = ItemStackHelper.getItemPrototype(itemPrototype);
             if (itemPrototype.isEmpty()) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/StorageRenderItem.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/StorageRenderItem.java
@@ -100,10 +100,10 @@ public class StorageRenderItem extends ItemRenderer
             return;
         }
 
-        item = ItemStackHelper.decodeItemStack(item);
-
         if (!item.isEmpty())
         {
+            item = ItemStackHelper.decodeItemStack(item);
+
             float scale = .5f;
             float xoff = 0;
             //if (font.getUnicodeFlag()) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ItemStackHelper.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ItemStackHelper.java
@@ -89,25 +89,39 @@ public class ItemStackHelper
     }
 
     public static ItemStack decodeItemStack (@Nonnull ItemStack stack) {
+        int count = ItemStackHelper.decodedCount(stack);
+        ItemStack decode = ItemStackHelper.stripDecoding(stack);
+        decode.setCount(count);
+        return decode;
+    }
+
+    public static ItemStack decodeItemStackPrototype (@Nonnull ItemStack stack) {
+        ItemStack decode = ItemStackHelper.stripDecoding(stack);
+        decode.setCount(1);
+        return decode;
+    }
+
+    public static int decodedCount (@Nonnull ItemStack stack) {
         CompoundNBT tag = stack.getTag();
-        if (tag == null)
-            return stack;
+        if (tag != null && tag.contains("__storagedrawers_count"))
+            return tag.getInt("__storagedrawers_count");
 
-        if (tag.contains("__storagedrawers_count")) {
-            ItemStack decode = stack.copy();
-            decode.setCount(tag.getInt("__storagedrawers_count"));
+        return stack.getCount();
+    }
 
-            tag = decode.getTag();
-            if (tag != null) {
-                decode.getTag().remove("__storagedrawers_count");
-                if (tag.size() == 0)
-                    decode.setTag(null);
-            }
+    public static ItemStack stripDecoding (@Nonnull ItemStack stack) {
+        ItemStack decode = stack.copy();
+        CompoundNBT tag = decode.getTag();
 
-            return decode;
+        if (tag != null && tag.contains("__storagedrawers_count")) {
+            tag.remove("__storagedrawers_count");
+            if (tag.size() == 0)
+                decode.setTag(null);
+            else
+                decode.setTag(tag);
         }
 
-        return stack;
+        return decode;
     }
 
     public static boolean isStackEncoded (@Nonnull ItemStack stack) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/SlotDrawer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/SlotDrawer.java
@@ -42,8 +42,8 @@ public class SlotDrawer extends Slot
 
     @Override
     public void putStack (@Nonnull ItemStack stack) {
-        stack = ItemStackHelper.decodeItemStack(stack);
         IDrawer target = drawer.setStoredItem(stack);
+        stack = ItemStackHelper.decodeItemStack(stack);
         target.setStoredItemCount(stack.getCount());
     }
 


### PR DESCRIPTION
Closes #810, #833, #863... at least for MC 1.15. For people not willing to compile their own copy, there's a built version with the fix available [here](https://shados.net/files/StorageDrawers-1.15.2-7.0.2-fix.jar).