### PR TITLE
Bump to version 1.16.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.jvmargs=-Xmx3G
 
 minecraft_base_version=1.16
-minecraft_version=1.16.2
-forge_version=1.16.2-33.0.5
+minecraft_version=1.16.3
+forge_version=1.16.3-34.1.0
 forge_mappings=20200723-1.16.1
 mod_version=8.1.0
 


### PR DESCRIPTION
I use your wonderful mod on a small server that I want to upgrade to 1.16.3, so I figured I'd try to help bump the version and maybe learn a bit about forge modding in the process.

I was able to build for 1.16.3 and was able to test it quickly in creative mode. Initially I also tried using more updated forge_mappings but that gave me some issues as some of the functions seemed to have changed signature.

Sorry for otherwise intruding, I understand that you may prefer to update your mods in your own time. No hard feelings if you close the PR :)

