### PR TITLE
Updated from 1.16.2 to 1.16.3 and updated to latest MCP and fixed all mappings as well as fixes Mekanism  Logistical Transporter not working with storage drawers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,15 +104,15 @@ minecraft {
 repositories {
     maven { // JEI
         name = "JEI repo"
-        url "http://dvs1.progwml6.com/files/maven"
+        url "https://dvs1.progwml6.com/files/maven"
     }
     maven { // CraftTweaker
         name = "jared maven"
-        url "http://maven.blamejared.com/"
+        url "https://maven.blamejared.com/"
     }
     maven { // HWYLA
         name = "HWYLA repo"
-        url "http://tehnut.info/maven"
+        url "https://maven.tehnut.info"
     }
     maven {
         name = "CurseForge"

--- a/build.gradle
+++ b/build.gradle
@@ -102,16 +102,20 @@ minecraft {
 }
 
 repositories {
-    maven { // JEI
-        name = "JEI repo"
+    maven {
+        name = "JEI"
         url "https://dvs1.progwml6.com/files/maven"
     }
-    maven { // CraftTweaker
-        name = "jared maven"
+    maven {
+        name = "CraftTweaker"
         url "https://maven.blamejared.com/"
     }
-    maven { // HWYLA
-        name = "HWYLA repo"
+    maven {
+        name 'TOP'
+        url "https://maven.tterrag.com/"
+    }
+    maven {
+        name = "HWYLA"
         url "https://maven.tehnut.info"
     }
     maven {
@@ -121,26 +125,38 @@ repositories {
 }
 
 dependencies {
-    minecraft "net.minecraftforge:forge:${project.forge_version}"
+    minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
     //compile chameleon
 
-    //compileOnly "mezz.jei:jei-${minecraft_version}:${jei_version}:api"
-    //compile fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}")
+    compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}:api")
+    runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}")
 
-    //compileOnly "mcp.mobius.waila:Hwyla:${hwyla_version}:api"
-    //compile fg.deobf("mcp.mobius.waila:Hwyla:${hwyla_version}")
+    compileOnly fg.deobf("mcjty.theoneprobe:TheOneProbe-1.16:${top_version}:api")
+    runtimeOnly fg.deobf("mcjty.theoneprobe:TheOneProbe-1.16:${top_version}")
+
+    compileOnly fg.deobf("mcp.mobius.waila:Hwyla:${hwyla_version}:api")
+    runtimeOnly fg.deobf("mcp.mobius.waila:Hwyla:${hwyla_version}")
 
     //deobfCompile "MineTweaker3:MineTweaker3-API:${mt_version}"
     //deobfCompile "org.ow2.asm:asm-debug-all:5.0.3"
+
+    compile fg.deobf("com.blamejared.crafttweaker:CraftTweaker-${minecraft_version}:${crafttweaker_version}")
 }
 
-processResources
-{
-    from (sourceSets.main.resources.srcDirs) {
-        include 'META-INF/mods.toml'
-        expand 'version': project.version
+task replaceResources(type: Copy) {
+    outputs.upToDateWhen { false }
+    from(sourceSets.main.resources) {
+        include "META-INF/mods.toml"
+        expand "version": mod_version, "mc_version": minecraft_version, "forge_version": min_forge_version, "loader_version": loader_version
     }
+    into "$buildDir/resources/main/"
+}
+
+processResources {
+    //Exclude the mods.toml file as we manually handle that and don't want it to invalidate our cache
+    exclude 'META-INF/mods.toml'
+    finalizedBy replaceResources
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,11 +2,18 @@ org.gradle.jvmargs=-Xmx3G
 
 minecraft_base_version=1.16
 minecraft_version=1.16.3
-forge_version=1.16.3-34.1.12
+forge_version=34.1.22
 forge_mappings=20200916-1.16.2
+loader_version=34
 mod_version=8.2.0
 
 # Mod dependency versions
 jei_version=7.3.2.36
 hwyla_version=1.10.11-B78_1.16.2
-mt_version=3.0.24.81
+# mt_version=3.0.24.81
+crafttweaker_version=7.0.0.45
+top_version=1.16-3.0.4-beta-7
+
+# This determines the minimum version of forge required
+# Only Change when mod need access to a feature in forge that is not available in earlier versions
+min_forge_version=34.1.14

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,12 @@
 org.gradle.jvmargs=-Xmx3G
 
 minecraft_base_version=1.16
-minecraft_version=1.16.2
-forge_version=1.16.2-33.0.5
-forge_mappings=20200723-1.16.1
-mod_version=8.1.0
+minecraft_version=1.16.3
+forge_version=1.16.3-34.1.12
+forge_mappings=20200916-1.16.2
+mod_version=8.2.0
 
-jei_version=6.0.0.11
-hwyla_version=1.10.5-B66_1.14.4
+# Mod dependency versions
+jei_version=7.3.2.36
+hwyla_version=1.10.11-B78_1.16.2
 mt_version=3.0.24.81

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
@@ -543,7 +543,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
             return;
 
         PacketDistributor.TargetPoint point = new PacketDistributor.TargetPoint(
-            getPos().getX(), getPos().getY(), getPos().getZ(), 500, getWorld().func_234923_W_());
+            getPos().getX(), getPos().getY(), getPos().getZ(), 500, getWorld().getDimensionKey());
         MessageHandler.INSTANCE.send(PacketDistributor.NEAR.with(() -> point), new CountUpdateMessage(getPos(), slot, count));
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersComp.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersComp.java
@@ -128,7 +128,7 @@ public class TileEntityDrawersComp extends TileEntityDrawers
         protected void onAmountChanged () {
             if (getWorld() != null && !getWorld().isRemote) {
                 PacketDistributor.TargetPoint point = new PacketDistributor.TargetPoint(
-                    getPos().getX(), getPos().getY(), getPos().getZ(), 500, getWorld().func_234923_W_());
+                    getPos().getX(), getPos().getY(), getPos().getZ(), 500, getWorld().getDimensionKey());
                 MessageHandler.INSTANCE.send(PacketDistributor.NEAR.with(() -> point), new CountUpdateMessage(getPos(), 0, getPooledCount()));
 
                 markDirty();

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/capabilities/DrawerItemHandler.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/capabilities/DrawerItemHandler.java
@@ -57,9 +57,9 @@ public class DrawerItemHandler implements IItemHandler
 
         if (slotIsVirtual(slot)) {
             //if (StorageDrawers.config.cache.enableItemConversion)
-            //    return insertItemFullScan(stack, simulate);
+                return insertItemFullScan(stack, simulate);
             //else
-                return stack;
+            //    return stack;
         }
 
         slot -= 1;
@@ -75,6 +75,14 @@ public class DrawerItemHandler implements IItemHandler
                     return insertItemFullScan(stack, simulate);
             }
         }*/
+        if (orderedSlot > 0) {
+            IDrawer drawer = group.getDrawer(orderedSlot);
+            if (drawer.isEnabled() && drawer.isEmpty()) {
+                IDrawer prevDrawer = group.getDrawer(prevSlot);
+                if (!prevDrawer.isEnabled() || !prevDrawer.isEmpty())
+                    return insertItemFullScan(stack, simulate);
+            }
+        }
 
         return insertItemInternal(orderedSlot, stack, simulate);
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
@@ -303,8 +303,8 @@ public final class BasicDrawerModel
         }
 
         @Override
-        public boolean func_230044_c_ () {
-            return mainModel.func_230044_c_();
+        public boolean isSideLit () {
+            return mainModel.isSideLit();
         }
 
         @Override
@@ -345,8 +345,8 @@ public final class BasicDrawerModel
         }
 
         @Override
-        public boolean func_230044_c_ () {
-            return mainModel.func_230044_c_();
+        public boolean isSideLit () {
+            return mainModel.isSideLit();
         }
 
         @Nonnull

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/ProxyBuilderModel.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/ProxyBuilderModel.java
@@ -78,9 +78,9 @@ public abstract class ProxyBuilderModel implements IBakedModel
     }
 
     @Override
-    public boolean func_230044_c_ () {
+    public boolean isSideLit () {
         IBakedModel model = getActiveModel();
-        return (model != null) ? model.func_230044_c_() : false;
+        return (model != null) ? model.isSideLit() : false;
     }
 
     public List<Object> getKey (BlockState state) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
@@ -64,14 +64,14 @@ public class TileEntityDrawersRenderer extends TileEntityRenderer<TileEntityDraw
         Direction side = state.get(BlockDrawers.HORIZONTAL_FACING);
 
         Minecraft mc = Minecraft.getInstance();
-        GraphicsFanciness cache = mc.gameSettings.field_238330_f_;
-        mc.gameSettings.field_238330_f_ = GraphicsFanciness.FANCY;
+        GraphicsFanciness cache = mc.gameSettings.graphicFanciness;
+        mc.gameSettings.graphicFanciness = GraphicsFanciness.FANCY;
         //renderUpgrades(renderer, tile, state);
 
         if (!tile.getDrawerAttributes().isConcealed())
             renderFastItemSet(tile, state, matrix, buffer, combinedLight, combinedOverlay, side, partialTickTime);
 
-        mc.gameSettings.field_238330_f_ = cache;
+        mc.gameSettings.graphicFanciness = cache;
 
         matrix.pop();
         RenderHelper.setupLevelDiffuseLighting(matrix.getLast().getMatrix());

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/DrawerScreen.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/DrawerScreen.java
@@ -78,7 +78,7 @@ public class DrawerScreen extends ContainerScreen<ContainerDrawers>
 
         this.renderBackground(stack);
         super.render(stack, p_render_1_, p_render_2_, p_render_3_);
-        this.func_230459_a_(stack, p_render_1_, p_render_2_);
+        this.renderHoveredTooltip(stack, p_render_1_, p_render_2_);
 
         container.activeRenderItem = null;
         storageItemRender.overrideStack = ItemStack.EMPTY;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[32,)"
+loaderVersion="[${loader_version},)"
 issueTrackerURL="https://github.com/jaquadro/StorageDrawers/issues"
 displayURL="https://minecraft.curseforge.com/projects/storagedrawers"
 authors="Texelsaur"
@@ -14,15 +14,13 @@ license="MIT"
     '''
 
 [[dependencies.storagedrawers]]
-    modId="forge"
-    mandatory=true
-    versionRange="[32,)"
-    ordering="NONE"
-    side="BOTH"
-
-[[dependencies.storagedrawers]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16,)"
+    versionRange="[${mc_version}]"
+    side="BOTH"
+[[dependencies.storagedrawers]]
+    modId="forge"
+    mandatory=true
+    versionRange="[${forge_version},)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
Updated from 1.16.2 to 1.16.3
Updated to latest MCP 20200916-1.16.2 and updated mapping
Updated dependecies to Latest 1.16.3 versions
Updated to latest Forge 34.1.22 which fixes tooltip issues and other misc forge related bugs see forge changelog for more details
Fixed malven related links to https
Updated HWYLA malven URL
Fixed Mekanism Logistical Transporter not working with storage drawers controller and 1x1 storage
close https://github.com/jaquadro/StorageDrawers/issues/811
close https://github.com/mekanism/Mekanism/issues/6637