### PR TITLE
1.16: resolve #910 Fix readme to use    fg.deobf  because deobfCompile  is dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@ repositories {
 }
 
 dependencies {
-    deobfCompile "com.jaquadro.minecraft.storagedrawers:StorageDrawers:<VERSION>:api"
+    fg.deobf  "com.jaquadro.minecraft.storagedrawers:StorageDrawers:<VERSION>:api"
     runtime "com.jaquadro.minecraft.storagedrawers:StorageDrawers:<VERSION>"
-    runtime "com.jaquadro.minecraft.chameleon:Chameleon:<VERSION>"
 }
 ```
 An example version is `1.12-5.2.2`. You can [browse the repo](https://dl.bintray.com/jaquadro/dev/com/jaquadro/minecraft/) to see what versions are available.


### PR DESCRIPTION
Chameleon does not exist in 1.16 also

https://github.com/jaquadro/StorageDrawers/issues/910