### PR TITLE
Add integration for TheOneProbe.

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
@@ -6,17 +6,20 @@ import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
 import com.jaquadro.minecraft.storagedrawers.config.CompTierRegistry;
 import com.jaquadro.minecraft.storagedrawers.core.*;
 import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityDrawerAttributes;
+import com.jaquadro.minecraft.storagedrawers.integration.TheOneProbe;
 import com.jaquadro.minecraft.storagedrawers.network.MessageHandler;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.apache.logging.log4j.LogManager;
@@ -45,6 +48,7 @@ public class StorageDrawers
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, CommonConfig.spec);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onModQueueEvent);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onModConfigEvent);
 
         MinecraftForge.EVENT_BUS.register(this);
@@ -77,6 +81,11 @@ public class StorageDrawers
 
     private void clientSetup (final FMLClientSetupEvent event) {
         ModBlocks.Registration.bindRenderTypes();
+    }
+
+    @SuppressWarnings("Convert2MethodRef")  // otherwise the class loader gets upset if TheOneProbe is not loaded
+    private void onModQueueEvent(final InterModEnqueueEvent event) {
+        InterModComms.sendTo("theoneprobe", "getTheOneProbe", () -> new TheOneProbe());
     }
 
     private void onModConfigEvent(final ModConfig.ModConfigEvent event) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/config/CommonConfig.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/config/CommonConfig.java
@@ -93,12 +93,18 @@ public final class CommonConfig
 
     public static class Integration {
         public final ForgeConfigSpec.ConfigValue<Boolean> wailaStackRemainder;
+        public final ForgeConfigSpec.BooleanValue wailaRespectQuantifyKey;
 
         public Integration (ForgeConfigSpec.Builder builder) {
             builder.push("Integration");
 
             wailaStackRemainder = builder
-                .define("wailaStackRemainder", true);
+                    .comment("When true, shows quantity as NxS + R (by stack size) rather than count")
+                    .define("wailaStackRemainder", true);
+
+            wailaRespectQuantifyKey = builder
+                    .comment("When true, does not show current quantities unless quantify key was used")
+                    .define("wailaRespectQuantifyKey", false);
 
             builder.pop();
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/DrawerOverlay.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/DrawerOverlay.java
@@ -1,0 +1,104 @@
+package com.jaquadro.minecraft.storagedrawers.integration;
+
+import com.jaquadro.minecraft.storagedrawers.api.storage.*;
+import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityDrawerAttributes;
+import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.IFormattableTextComponent;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DrawerOverlay {
+    public boolean showContent = true;
+    public boolean showStackLimit = true;
+    public boolean showStatus = true;
+    public boolean showStackRemainder = CommonConfig.INTEGRATION.wailaStackRemainder.get();
+    public boolean respectQuantifyKey = CommonConfig.INTEGRATION.wailaRespectQuantifyKey.get();
+
+    public List<ITextComponent> getOverlay(final TileEntityDrawers tile) {
+        final List<ITextComponent> result = new ArrayList<>();
+
+        final IDrawerAttributes attr = tile.getCapability(CapabilityDrawerAttributes.DRAWER_ATTRIBUTES_CAPABILITY, null).orElse(EmptyDrawerAttributes.EMPTY);
+        addContent(result, tile, attr);
+        addStackLimit(result, tile, attr);
+        addStatus(result, tile, attr);
+
+        return result;
+    }
+
+    private void addContent(final List<ITextComponent> result, final TileEntityDrawers tile, final IDrawerAttributes attr) {
+        if (!this.showContent || attr.isConcealed()) return;
+        final boolean showCounts = !this.respectQuantifyKey || attr.isShowingQuantity();
+
+        final IDrawerGroup group = tile.getGroup();
+        for (int i = 0; i < group.getDrawerCount(); i++) {
+            final IDrawer drawer = group.getDrawer(i);
+            if (!drawer.isEnabled())
+                continue;
+
+            ITextComponent name = new TranslationTextComponent("tooltip.storagedrawers.waila.empty");
+
+            final ItemStack stack = drawer.getStoredItemPrototype();
+            if (!stack.isEmpty()) {
+                final IFormattableTextComponent stackName = new StringTextComponent("").append(stack.getDisplayName());
+
+                if (showCounts) {
+                    if (drawer.getStoredItemCount() == Integer.MAX_VALUE) {
+                        name = stackName.appendString("[\u221E]");
+                    } else if (drawer instanceof IFractionalDrawer && ((IFractionalDrawer) drawer).getConversionRate() > 1) {
+                        final String text = ((i == 0) ? " [" : " [+") + ((IFractionalDrawer) drawer).getStoredItemRemainder() + "]";
+                        name = stackName.appendString(text);
+                    } else if (this.showStackRemainder) {
+                        final int stacks = drawer.getStoredItemCount() / drawer.getStoredItemStackSize();
+                        final int remainder = drawer.getStoredItemCount() - (stacks * drawer.getStoredItemStackSize());
+                        if (stacks > 0 && remainder > 0)
+                            name = stackName.appendString(" [" + stacks + "x" + drawer.getStoredItemStackSize() + " + " + remainder + "]");
+                        else if (stacks > 0)
+                            name = stackName.appendString(" [" + stacks + "x" + drawer.getStoredItemStackSize() + "]");
+                        else
+                            name = stackName.appendString(" [" + remainder + "]");
+                    } else
+                        name = stackName.appendString(" [" + drawer.getStoredItemCount() + "]");
+                } else {
+                    name = stackName;
+                }
+            }
+            result.add(new TranslationTextComponent("tooltip.storagedrawers.waila.drawer", i + 1, name));
+        }
+
+    }
+
+    private void addStackLimit(List<ITextComponent> result, TileEntityDrawers tile, IDrawerAttributes attr) {
+        if (!this.showStackLimit) return;
+
+        if (attr.isUnlimitedStorage() || tile.getDrawerAttributes().isUnlimitedVending())
+            result.add(new TranslationTextComponent("tooltip.storagedrawers.waila.nolimit"));
+        else {
+            int multiplier = tile.upgrades().getStorageMultiplier();
+            int limit = tile.getEffectiveDrawerCapacity() * multiplier;
+            result.add(new TranslationTextComponent("tooltip.storagedrawers.waila.limit", limit, multiplier));
+        }
+    }
+
+    private void addStatus(List<ITextComponent> result, TileEntityDrawers tile, IDrawerAttributes attr) {
+        if (!this.showStatus) return;
+
+        List<IFormattableTextComponent> attribs = new ArrayList<>();
+        if (attr.isItemLocked(LockAttribute.LOCK_POPULATED))
+            attribs.add(new TranslationTextComponent("tooltip.storagedrawers.waila.locked"));
+        if (attr.isVoid())
+            attribs.add(new TranslationTextComponent("tooltip.storagedrawers.waila.void"));
+        //if (tile.getOwner() != null)
+        //    attribs.add(new TranslationTextComponent("tooltip.storagedrawers.waila.protected"));
+
+        if (!attribs.isEmpty())
+            result.add(attribs.stream().reduce((a, b) ->
+                    a.append(new StringTextComponent(", ")).append(b)).get());
+    }
+}

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/TheOneProbe.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/TheOneProbe.java
@@ -1,0 +1,41 @@
+package com.jaquadro.minecraft.storagedrawers.integration;
+
+import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import mcjty.theoneprobe.api.*;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.world.World;
+
+import java.util.function.Function;
+
+public class TheOneProbe implements Function<ITheOneProbe, Void> {
+    @Override
+    public Void apply(ITheOneProbe probe) {
+        probe.registerProvider(new DrawerProbeProvider());
+        return null;
+    }
+
+    private static class DrawerProbeProvider implements IProbeInfoProvider {
+        @Override
+        public String getID() {
+            return new ResourceLocation(StorageDrawers.MOD_ID, "drawerprobe").toString();
+        }
+
+        @Override
+        public void addProbeInfo(ProbeMode probeMode, IProbeInfo probe, PlayerEntity player, World world, BlockState blockState, IProbeHitData data) {
+            TileEntity tile = world.getTileEntity(data.getPos());
+            if (tile instanceof TileEntityDrawers) {
+                TileEntityDrawers drawers = (TileEntityDrawers) tile;
+
+                DrawerOverlay overlay = new DrawerOverlay();
+                for (ITextComponent component : overlay.getOverlay(drawers)) {
+                    probe.text(component);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
@@ -1,26 +1,14 @@
 package com.jaquadro.minecraft.storagedrawers.integration;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.api.storage.EmptyDrawerAttributes;
-import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
-import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributes;
-import com.jaquadro.minecraft.storagedrawers.api.storage.IFractionalDrawer;
-import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
-import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityDrawerAttributes;
-import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
 import mcp.mobius.waila.api.*;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.IFormattableTextComponent;
 import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.StringTextComponent;
-import net.minecraft.util.text.TranslationTextComponent;
 
 import javax.annotation.Nonnull;
-
 import java.util.List;
 
 @WailaPlugin(StorageDrawers.MOD_ID)
@@ -51,67 +39,13 @@ public class Waila implements IWailaPlugin
         @Override
         public void appendBody (List<ITextComponent> currenttip, IDataAccessor accessor, IPluginConfig config) {
             TileEntityDrawers tile = (TileEntityDrawers) accessor.getTileEntity();
-            IDrawerAttributes attr = tile.getCapability(CapabilityDrawerAttributes.DRAWER_ATTRIBUTES_CAPABILITY, null).orElse(EmptyDrawerAttributes.EMPTY);
 
-            //if (SecurityManager.hasAccess(Minecraft.getInstance().player.getGameProfile(), tile)) {
-                if (config.get(new ResourceLocation(StorageDrawers.MOD_ID, "display.content"))) {
-                    for (int i = 0; i < tile.getDrawerCount(); i++) {
-                        IDrawer drawer = tile.getDrawer(i);
-                        if (!drawer.isEnabled())
-                            continue;
+            DrawerOverlay overlay = new DrawerOverlay();
+            overlay.showContent = config.get(new ResourceLocation(StorageDrawers.MOD_ID, "display.content"));
+            overlay.showStackLimit = config.get(new ResourceLocation(StorageDrawers.MOD_ID, "display.stacklimit"));
+            overlay.showStatus = config.get(new ResourceLocation(StorageDrawers.MOD_ID, "display.status"));
 
-                        ITextComponent name = new TranslationTextComponent("tooltip.storagedrawers.waila.empty");
-
-                        ItemStack stack = drawer.getStoredItemPrototype();
-                        if (!stack.isEmpty()) {
-                            IFormattableTextComponent stackName = new StringTextComponent("").append(stack.getDisplayName());
-
-                            if (drawer.getStoredItemCount() == Integer.MAX_VALUE) {
-                                name = stackName.appendString("[\u221E]");
-                            }
-                            else if (drawer instanceof IFractionalDrawer && ((IFractionalDrawer) drawer).getConversionRate() > 1) {
-                                String text = ((i == 0) ? " [" : " [+") + ((IFractionalDrawer) drawer).getStoredItemRemainder() + "]";
-                                name = stackName.appendString(text);
-                            }
-                            else if (CommonConfig.INTEGRATION.wailaStackRemainder.get()) {
-                                int stacks = drawer.getStoredItemCount() / drawer.getStoredItemStackSize();
-                                int remainder = drawer.getStoredItemCount() - (stacks * drawer.getStoredItemStackSize());
-                                if (stacks > 0 && remainder > 0)
-                                    name = stackName.appendString(" [" + stacks + "x" + drawer.getStoredItemStackSize() + " + " + remainder + "]");
-                                else if (stacks > 0)
-                                    name = stackName.appendString(" [" + stacks + "x" + drawer.getStoredItemStackSize() + "]");
-                                else
-                                    name = stackName.appendString(" [" + remainder + "]");
-                            } else
-                                name = stackName.appendString(" [" + drawer.getStoredItemCount() + "]");
-                        }
-                        currenttip.add(new TranslationTextComponent("tooltip.storagedrawers.waila.drawer", i + 1, name));
-                    }
-                }
-
-                if (config.get(new ResourceLocation(StorageDrawers.MOD_ID, "display.stacklimit"))) {
-                    if (tile.getDrawerAttributes().isUnlimitedStorage() || tile.getDrawerAttributes().isUnlimitedVending())
-                        currenttip.add(new TranslationTextComponent("tooltip.storagedrawers.waila.nolimit"));
-                    else {
-                        int multiplier = tile.upgrades().getStorageMultiplier();
-                        int limit = tile.getEffectiveDrawerCapacity() * multiplier;
-                        currenttip.add(new TranslationTextComponent("tooltip.storagedrawers.waila.limit", limit, multiplier));
-                    }
-                }
-            //}
-
-            if (config.get(new ResourceLocation(StorageDrawers.MOD_ID, "display.status"))) {
-                String attrib = "";
-                if (attr.isItemLocked(LockAttribute.LOCK_POPULATED))
-                    attrib += (attrib.isEmpty() ? "" : ", ") + I18n.format("tooltip.storagedrawers.waila.locked");
-                if (attr.isVoid())
-                    attrib += (attrib.isEmpty() ? "" : ", ") + I18n.format("tooltip.storagedrawers.waila.void");
-                //if (tile.getOwner() != null)
-                //    attrib += (attrib.isEmpty() ? "" : ", ") + I18n.format("storagedrawers.waila.protected");
-
-                if (!attrib.isEmpty())
-                    currenttip.add(new StringTextComponent(attrib));
-            }
+            currenttip.addAll(overlay.getOverlay(tile));
         }
     }
 }


### PR DESCRIPTION
Also add setting to make the overlay hide the quantity unless the quantify key has been used (off by default).

I wasn't sure what to do about the config settings; TheOneProbe doesn't have plugin settings like WAILA did, so if you still want config then it'd have to be added to CommonConfig (which would be easy enough; I can do that if you like).  But for consistency we should probably get rid of the WAILA config settings in that case.  For now, TOP just assumes you always want everything enabled.

This uses common code for generating both overlays, for consistency.  This unfortunately does mean that you can't take advantage of some of TOP's more advanced features, such as the ability to display the image of the item in each drawer as well as the name.  That would require a **lot** more code to provide, especially if you want to keep TOP an optional dependency.