### PR TITLE
Support nullable player in UseContext

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -231,7 +231,7 @@ public abstract class BlockDrawers extends HorizontalBlock implements INetworked
 
     @Override
     public boolean isReplaceable (BlockState state, BlockItemUseContext useContext) {
-        if (useContext.getPlayer().isCreative() && useContext.getHand() == Hand.OFF_HAND) {
+        if (useContext.getPlayer() && useContext.getPlayer().isCreative() && useContext.getHand() == Hand.OFF_HAND) {
             double blockReachDistance = useContext.getPlayer().getAttribute(net.minecraftforge.common.ForgeMod.REACH_DISTANCE.get()).getValue() + 1;
             BlockRayTraceResult result = rayTraceEyes(useContext.getWorld(), useContext.getPlayer(), blockReachDistance);
 


### PR DESCRIPTION
Unable to run with Astal Sorcery because of [this](https://github.com/HellFirePvP/AstralSorcery/blob/e1b8c88ba71360c36232abfafc9b97406c63c398/src/main/java/hellfirepvp/astralsorcery/common/util/block/TestBlockUseContext.java#L35).

Method getPlayer() marked as Nullable in ItemUseContext, so we have to check it for it's state

[Crash](https://pastebin.com/X3vpxvyv)