### PR TITLE
Add recipe to add upgrades to drawers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ runtime-1.9/
 build/
 .idea/
 run/
+/bin/
+/.settings/
+/.classpath
+/.project
+*.launch

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ plugins {
 
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'idea'
+apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
 //evaluationDependsOn(":..:Chameleon-${minecraft_base_version}")

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
@@ -6,20 +6,28 @@ import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
 import com.jaquadro.minecraft.storagedrawers.config.CompTierRegistry;
 import com.jaquadro.minecraft.storagedrawers.core.*;
+import com.jaquadro.minecraft.storagedrawers.core.recipe.AddUpgradeRecipe;
 import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.network.MessageHandler;
+
+import net.minecraft.item.crafting.IRecipeSerializer;
+import net.minecraft.item.crafting.SpecialRecipeSerializer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModLoadingContext;
+import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -40,6 +48,9 @@ public class StorageDrawers
     //public static WailaRegistry wailaRegistry;
     //public static SecurityRegistry securityRegistry;
 
+    private static final DeferredRegister<IRecipeSerializer<?>> RECIPES = DeferredRegister.create(ForgeRegistries.RECIPE_SERIALIZERS, MOD_ID);
+    public static final RegistryObject<IRecipeSerializer<AddUpgradeRecipe>> UPRADE_RECIPE_SERIALIZER = RECIPES.register("add_upgrade", () -> new SpecialRecipeSerializer<>(AddUpgradeRecipe::new));
+
     public StorageDrawers () {
         proxy = DistExecutor.runForDist(() -> ClientProxy::new, () -> CommonProxy::new);
 
@@ -48,6 +59,7 @@ public class StorageDrawers
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onModConfigEvent);
+        RECIPES.register(FMLJavaModLoadingContext.get().getModEventBus());
 
         MinecraftForge.EVENT_BUS.register(this);
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
@@ -49,7 +49,7 @@ public class StorageDrawers
     //public static SecurityRegistry securityRegistry;
 
     private static final DeferredRegister<IRecipeSerializer<?>> RECIPES = DeferredRegister.create(ForgeRegistries.RECIPE_SERIALIZERS, MOD_ID);
-    public static final RegistryObject<IRecipeSerializer<AddUpgradeRecipe>> UPRADE_RECIPE_SERIALIZER = RECIPES.register("add_upgrade", () -> new SpecialRecipeSerializer<>(AddUpgradeRecipe::new));
+    public static final RegistryObject<IRecipeSerializer<AddUpgradeRecipe>> UPGRADE_RECIPE_SERIALIZER = RECIPES.register("add_upgrade", () -> new SpecialRecipeSerializer<>(AddUpgradeRecipe::new));
 
     public StorageDrawers () {
         proxy = DistExecutor.runForDist(() -> ClientProxy::new, () -> CommonProxy::new);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/UpgradeData.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/UpgradeData.java
@@ -15,7 +15,7 @@ import javax.annotation.Nonnull;
 
 public class UpgradeData extends TileDataShim
 {
-    private final ItemStack[] upgrades;
+    protected final ItemStack[] upgrades;
     private int storageMultiplier;
     private EnumUpgradeStatus statusType;
     private EnumUpgradeRedstone redstoneType;
@@ -51,6 +51,10 @@ public class UpgradeData extends TileDataShim
     public ItemStack getUpgrade (int slot) {
         slot = MathHelper.clamp(slot, 0, upgrades.length - 1);
         return upgrades[slot];
+    }
+
+    public boolean hasEmptySlot() {
+        return getNextUpgradeSlot() != -1;
     }
 
     public boolean addUpgrade (@Nonnull ItemStack upgrade) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/recipe/AddUpgradeRecipe.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/recipe/AddUpgradeRecipe.java
@@ -99,7 +99,7 @@ public class AddUpgradeRecipe extends SpecialRecipe {
 
     @Override
     public IRecipeSerializer<?> getSerializer() {
-        return StorageDrawers.UPRADE_RECIPE_SERIALIZER.get();
+        return StorageDrawers.UPGRADE_RECIPE_SERIALIZER.get();
     }
 
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/recipe/AddUpgradeRecipe.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/recipe/AddUpgradeRecipe.java
@@ -1,0 +1,105 @@
+package com.jaquadro.minecraft.storagedrawers.core.recipe;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.UpgradeData;
+import com.jaquadro.minecraft.storagedrawers.core.ModItems;
+import com.jaquadro.minecraft.storagedrawers.item.ItemDrawers;
+import com.jaquadro.minecraft.storagedrawers.item.ItemUpgrade;
+
+import net.minecraft.inventory.CraftingInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipeSerializer;
+import net.minecraft.item.crafting.SpecialRecipe;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+
+public class AddUpgradeRecipe extends SpecialRecipe {
+    public AddUpgradeRecipe(ResourceLocation name) {
+        super(name);
+    }
+
+    @Override
+    public boolean matches(CraftingInventory inv, World world) {
+        return findContext(inv) != null;
+    }
+
+    @Override
+    public ItemStack getCraftingResult(CraftingInventory inv) {
+        Context ctx = findContext(inv);
+        if (ctx == null)
+            return ItemStack.EMPTY;
+        ItemStack ret = ctx.drawer.copy();
+        ret.getOrCreateTag().put("tile", ctx.data.write(ret.getOrCreateTag().getCompound("tile")));
+        return ret;
+    }
+
+    private static class Context {
+        ItemStack drawer = ItemStack.EMPTY;
+        List<ItemStack> upgrades = new ArrayList<>();
+        UpgradeData data = null;
+    }
+
+    @Nullable
+    private Context findContext(CraftingInventory inv) {
+        Context ret = new Context();
+        for (int x = 0; x < inv.getSizeInventory(); x++) {
+            ItemStack stack = inv.getStackInSlot(x);
+            if (stack.isEmpty())
+                continue;
+
+            if (stack.getItem() instanceof ItemDrawers) {
+                if (!ret.drawer.isEmpty())
+                    return null;
+                ret.drawer = stack;
+            } else if (stack.getItem() instanceof ItemUpgrade)
+                ret.upgrades.add(stack);
+            else
+                return null;
+        }
+
+        if (ret.drawer.isEmpty() || ret.upgrades.isEmpty())
+            return null;
+
+        ret.data = new UpgradeData(7) { //Hard coded to 7 as the only use is TileEntityDrawers$DrawerUpgradeData
+            @Override
+            public boolean setUpgrade(int slot, @Nonnull ItemStack upgrade) { //Override this to bypass a lot of the complex logic
+                if (upgrade.isEmpty())
+                    return false;
+                upgrade = upgrade.copy();
+                upgrade.setCount(1);
+                super.upgrades[slot] = upgrade;
+                return true;
+            }
+        };
+
+        if (ret.drawer.hasTag() && ret.drawer.getTag().contains("tile"))
+            ret.data.read(ret.drawer.getTag().getCompound("tile"));
+
+        for (ItemStack upgrade : ret.upgrades) {
+            if (upgrade.getItem() == ModItems.ONE_STACK_UPGRADE)
+                return null; //I don't want to dig into finding the stack sizes to check if we can downgrade. So just don't allow this one >.>
+            if (!ret.data.hasEmptySlot() || !ret.data.canAddUpgrade(upgrade))
+                return null;
+            ret.data.addUpgrade(upgrade);
+        }
+
+        return ret;
+    }
+
+    @Override
+    public boolean canFit(int width, int height) {
+        return width * height >= 2;
+    }
+
+    @Override
+    public IRecipeSerializer<?> getSerializer() {
+        return StorageDrawers.UPRADE_RECIPE_SERIALIZER.get();
+    }
+
+}

--- a/src/main/resources/data/storagedrawers/recipes/add_upgrade.json
+++ b/src/main/resources/data/storagedrawers/recipes/add_upgrade.json
@@ -1,0 +1,3 @@
+{
+    "type": "storagedrawers:add_upgrade"
+}


### PR DESCRIPTION
Once we get into the somewhat mid game of most packs, I always get to the point where i'm making tons of drawers all max out capacity wise with a void upgrade. I figured it would be nice to make this automatable in a easy way so I added a crafting recipe to inject upgrades. 

I tried to keep the code changes simple, only real thing I changed was making the upgrades array protected and exposing a 'hasEmptySlots' in UpgradeData.

![](https://i.imgur.com/sZwk98K.png)

On a side note, I would say you should look into:
Upgrading to FG4/Gradle 6.9 when you get a chance it'll cleanup your buildscript
Upgrading to DeferredRegisters and not using @ObjectHolder. It'll help cleanup your init code.
Looking into using data generators, as it's a lot easier then editing jsons.
Just saying, not complaining.