### PR TITLE
Make drawers properly block light

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -72,11 +72,10 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
     // TODO: TE.getModelData()
     //public static final IUnlistedProperty<DrawerStateModelData> STATE_MODEL = UnlistedModelData.create(DrawerStateModelData.class);
 
-    private static final VoxelShape AABB_FULL = Block.box(0, 0, 0, 16, 16, 16);
-    private static final VoxelShape AABB_NORTH_FULL = Shapes.join(AABB_FULL, Block.box(1, 1, 0, 15, 15, 1), BooleanOp.ONLY_FIRST);
-    private static final VoxelShape AABB_SOUTH_FULL = Shapes.join(AABB_FULL, Block.box(1, 1, 15, 15, 15, 16), BooleanOp.ONLY_FIRST);
-    private static final VoxelShape AABB_WEST_FULL = Shapes.join(AABB_FULL, Block.box(0, 1, 1, 1, 15, 15), BooleanOp.ONLY_FIRST);
-    private static final VoxelShape AABB_EAST_FULL = Shapes.join(AABB_FULL, Block.box(15, 1, 1, 16, 15, 15), BooleanOp.ONLY_FIRST);
+    private static final VoxelShape AABB_NORTH_FULL = Shapes.join(Shapes.block(), Block.box(1, 1, 0, 15, 15, 1), BooleanOp.ONLY_FIRST);
+    private static final VoxelShape AABB_SOUTH_FULL = Shapes.join(Shapes.block(), Block.box(1, 1, 15, 15, 15, 16), BooleanOp.ONLY_FIRST);
+    private static final VoxelShape AABB_WEST_FULL = Shapes.join(Shapes.block(), Block.box(0, 1, 1, 1, 15, 15), BooleanOp.ONLY_FIRST);
+    private static final VoxelShape AABB_EAST_FULL = Shapes.join(Shapes.block(), Block.box(15, 1, 1, 16, 15, 15), BooleanOp.ONLY_FIRST);
     private static final VoxelShape AABB_NORTH_HALF = Block.box(0, 0, 8, 16, 16, 16);
     private static final VoxelShape AABB_SOUTH_HALF = Block.box(0, 0, 0, 16, 16, 8);
     private static final VoxelShape AABB_WEST_HALF = Block.box(8, 0, 0, 16, 16, 16);
@@ -97,12 +96,7 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
 
     private long ignoreEventTime;
 
-    private static final ThreadLocal<Boolean> inTileLookup = new ThreadLocal<Boolean>() {
-        @Override
-        protected Boolean initialValue () {
-            return false;
-        }
-    };
+    private static final ThreadLocal<Boolean> inTileLookup = ThreadLocal.withInitial(() -> false);
 
     public BlockDrawers (int drawerCount, boolean halfDepth, int storageUnits, BlockBehaviour.Properties properties) {
         super(properties);
@@ -430,18 +424,13 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
     }
 
     protected boolean hitLeft (Direction side, double hitX, double hitZ) {
-        switch (side) {
-            case NORTH:
-                return hitX > .5;
-            case SOUTH:
-                return hitX < .5;
-            case WEST:
-                return hitZ < .5;
-            case EAST:
-                return hitZ > .5;
-            default:
-                return true;
-        }
+        return switch (side) {
+            case NORTH -> hitX > .5;
+            case SOUTH -> hitX < .5;
+            case WEST -> hitZ < .5;
+            case EAST -> hitZ > .5;
+            default -> true;
+        };
     }
 
     protected BlockHitResult rayTraceEyes(Level world, Player player, double length) {
@@ -683,5 +672,9 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
         return (side == Direction.UP) ? getSignal(state, worldIn, pos, side) : 0;
     }
 
-
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean useShapeForLightOcclusion(BlockState state) {
+        return true;
+    }
 }


### PR DESCRIPTION
Ever since playing with this mod on 1.16 I noticed that walls of drawers don't block light, which felt very unnatural.
I tried to look up whether this is intentional or not and only found this ancient issue: https://github.com/jaquadro/StorageDrawers/issues/90, which indicates that most likely it's not.
This is simple fix for BlockDrawers that brings back occlusion, as well as some minor changes to the file.

Here are a couple screenshots showcasing the problem and the fix.
Before:
![2022-04-10_21 04 29](https://user-images.githubusercontent.com/7419124/162634521-49a43aa2-3b96-4884-b57e-a5650befc0f4.png)
![2022-04-10_21 04 32](https://user-images.githubusercontent.com/7419124/162634522-1c9b592e-006f-4556-ba38-f9a7bfd2d773.png)
After:
![2022-04-10_21 07 10](https://user-images.githubusercontent.com/7419124/162634523-6ff52bbf-ef39-4b49-8593-c71ccf3ac334.png)
![2022-04-10_21 07 14](https://user-images.githubusercontent.com/7419124/162634524-51177ef8-b986-41f6-bbb9-6413077bf955.png)

