### PR TITLE
Migrating from ObjectHolders to DeferredRegisters

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
@@ -1,5 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers;
 
+import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityDrawerGroup;
 import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityItemRepository;
 import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
@@ -7,16 +8,15 @@ import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
 import com.jaquadro.minecraft.storagedrawers.config.CompTierRegistry;
 import com.jaquadro.minecraft.storagedrawers.core.*;
 import com.jaquadro.minecraft.storagedrawers.core.recipe.AddUpgradeRecipe;
-import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.integration.TheOneProbe;
 import com.jaquadro.minecraft.storagedrawers.network.MessageHandler;
-
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.SimpleRecipeSerializer;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.InterModComms;
@@ -24,13 +24,11 @@ import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-
 import net.minecraftforge.registries.RegistryObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -60,10 +58,17 @@ public class StorageDrawers
 
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, CommonConfig.spec);
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ClientConfig.spec);
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onModQueueEvent);
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onModConfigEvent);
+
+        IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
+
+        ModBlocks.register(bus);
+        ModItems.register(bus);
+        ModBlockEntities.register(bus);
+
+        bus.addListener(this::setup);
+        bus.addListener(this::onModQueueEvent);
+        bus.addListener(this::onModConfigEvent);
+
         RECIPES.register(FMLJavaModLoadingContext.get().getModEventBus());
 
         MinecraftForge.EVENT_BUS.register(this);
@@ -88,10 +93,6 @@ public class StorageDrawers
         //compRegistry.initialize();
 
         //LocalIntegrationRegistry.instance().postInit();
-    }
-
-    private void clientSetup (final FMLClientSetupEvent event) {
-        ModBlocks.Registration.bindRenderTypes();
     }
 
     @SuppressWarnings("Convert2MethodRef")  // otherwise the class loader gets upset if TheOneProbe is not loaded

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockController.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockController.java
@@ -5,29 +5,28 @@ import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
 import com.jaquadro.minecraft.storagedrawers.core.ModItems;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.core.Direction;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.phys.BlockHitResult;
 
 import java.util.EnumSet;
 import java.util.Random;
-
-import net.minecraft.world.level.block.state.BlockBehaviour;
 
 public class BlockController extends HorizontalDirectionalBlock implements INetworked, EntityBlock
 {
@@ -71,11 +70,11 @@ public class BlockController extends HorizontalDirectionalBlock implements INetw
         if (world.isClientSide || item == null)
             return false;
 
-        if (item == ModItems.DRAWER_KEY)
+        if (item == ModItems.DRAWER_KEY.get())
             toggle(world, pos, player, EnumKeyType.DRAWER);
-        else if (item == ModItems.SHROUD_KEY)
+        else if (item == ModItems.SHROUD_KEY.get())
             toggle(world, pos, player, EnumKeyType.CONCEALMENT);
-        else if (item == ModItems.QUANTIFY_KEY)
+        else if (item == ModItems.QUANTIFY_KEY.get())
             toggle(world, pos, player, EnumKeyType.QUANTIFY);
         //else if (item == ModItems.personalKey)
         //    toggle(world, pos, player, EnumKeyType.PERSONAL);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -14,57 +14,56 @@ import com.jaquadro.minecraft.storagedrawers.inventory.ContainerDrawers4;
 import com.jaquadro.minecraft.storagedrawers.inventory.ContainerDrawersComp;
 import com.jaquadro.minecraft.storagedrawers.item.ItemKey;
 import com.jaquadro.minecraft.storagedrawers.item.ItemUpgrade;
+import net.minecraft.Util;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.MenuProvider;
-import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraft.world.phys.shapes.Shapes;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
-import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.network.NetworkHooks;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-
-import net.minecraft.Util;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.sounds.SoundEvents;
-import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.world.level.ClipContext;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.HorizontalDirectionalBlock;
-import net.minecraft.world.level.block.state.BlockBehaviour;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.HitResult;
-import net.minecraftforge.network.NetworkHooks;
 
 public abstract class BlockDrawers extends HorizontalDirectionalBlock implements INetworked, EntityBlock
 {
@@ -236,7 +235,7 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
             //    tile.setCustomName(stack.getDisplayName());
         }
 
-        if (entity != null && entity.getOffhandItem().getItem() == ModItems.DRAWER_KEY) {
+        if (entity != null && entity.getOffhandItem().getItem() == ModItems.DRAWER_KEY.get()) {
             TileEntityDrawers tile = getTileEntity(world, pos);
             if (tile != null) {
                 IDrawerAttributes _attrs = tile.getCapability(CapabilityDrawerAttributes.DRAWER_ATTRIBUTES_CAPABILITY).orElse(new EmptyDrawerAttributes());

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityController.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityController.java
@@ -4,27 +4,26 @@ import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.capabilities.IItemRepository;
 import com.jaquadro.minecraft.storagedrawers.api.security.ISecurityProvider;
 import com.jaquadro.minecraft.storagedrawers.api.storage.*;
-
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.IProtectable;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
 import com.jaquadro.minecraft.storagedrawers.block.BlockSlave;
+import com.jaquadro.minecraft.storagedrawers.capabilities.DrawerItemHandler;
 import com.jaquadro.minecraft.storagedrawers.capabilities.DrawerItemRepository;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
+import com.jaquadro.minecraft.storagedrawers.core.ModBlockEntities;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
-import com.jaquadro.minecraft.storagedrawers.capabilities.DrawerItemHandler;
 import com.jaquadro.minecraft.storagedrawers.security.SecurityManager;
 import com.jaquadro.minecraft.storagedrawers.util.ItemCollectionRegistry;
 import com.mojang.authlib.GameProfile;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.core.Direction;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.ticks.LevelTickAccess;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
@@ -159,7 +158,7 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
     }
 
     public TileEntityController (BlockPos pos, BlockState state) {
-        this(ModBlocks.Tile.CONTROLLER, pos, state);
+        this(ModBlockEntities.CONTROLLER.get(), pos, state);
     }
 
     public void printDebugInfo () {
@@ -173,8 +172,8 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
     public void clearRemoved () {
         super.clearRemoved();
 
-        if (!getLevel().getBlockTicks().hasScheduledTick(getBlockPos(), ModBlocks.CONTROLLER))
-            getLevel().scheduleTick(getBlockPos(), ModBlocks.CONTROLLER, 1);
+        if (!getLevel().getBlockTicks().hasScheduledTick(getBlockPos(), ModBlocks.CONTROLLER.get()))
+            getLevel().scheduleTick(getBlockPos(), ModBlocks.CONTROLLER.get(), 1);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
@@ -97,7 +97,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
             if (!super.canAddUpgrade(upgrade))
                 return false;
 
-            if (upgrade.getItem() == ModItems.ONE_STACK_UPGRADE) {
+            if (upgrade.getItem() == ModItems.ONE_STACK_UPGRADE.get()) {
                 int lostStackCapacity = upgradeData.getStorageMultiplier() * (getEffectiveDrawerCapacity() - 1);
                 if (!stackCapacityCheck(lostStackCapacity))
                     return false;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersComp.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersComp.java
@@ -8,15 +8,15 @@ import com.jaquadro.minecraft.storagedrawers.block.BlockCompDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.EnumCompDrawer;
 import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.FractionalDrawerGroup;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
-import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
+import com.jaquadro.minecraft.storagedrawers.core.ModBlockEntities;
 import com.jaquadro.minecraft.storagedrawers.network.CountUpdateMessage;
 import com.jaquadro.minecraft.storagedrawers.network.MessageHandler;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.capabilities.Capability;
@@ -41,7 +41,7 @@ public class TileEntityDrawersComp extends TileEntityDrawers
         private GroupData groupData = new GroupData(3);
 
         public Slot3 (BlockPos pos, BlockState state) {
-            super(ModBlocks.Tile.FRACTIONAL_DRAWERS_3, pos, state);
+            super(ModBlockEntities.FRACTIONAL_DRAWERS_3.get(), pos, state);
             groupData.setCapabilityProvider(this);
             injectPortableData(groupData);
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersStandard.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersStandard.java
@@ -5,11 +5,11 @@ import com.jaquadro.minecraft.storagedrawers.api.event.DrawerPopulatedEvent;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
 import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.StandardDrawerGroup;
-import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
-import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockState;
+import com.jaquadro.minecraft.storagedrawers.core.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
@@ -18,8 +18,6 @@ import net.minecraftforge.common.util.LazyOptional;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.StandardDrawerGroup.DrawerData;
 
 public class TileEntityDrawersStandard extends TileEntityDrawers
 {
@@ -40,7 +38,7 @@ public class TileEntityDrawersStandard extends TileEntityDrawers
         private GroupData groupData = new GroupData(1);
 
         public Slot1 (BlockPos pos, BlockState state) {
-            super(ModBlocks.Tile.STANDARD_DRAWERS_1, pos, state);
+            super(ModBlockEntities.STANDARD_DRAWERS_1.get(), pos, state);
             groupData.setCapabilityProvider(this);
             injectPortableData(groupData);
         }
@@ -62,7 +60,7 @@ public class TileEntityDrawersStandard extends TileEntityDrawers
         private GroupData groupData = new GroupData(2);
 
         public Slot2 (BlockPos pos, BlockState state) {
-            super(ModBlocks.Tile.STANDARD_DRAWERS_2, pos, state);
+            super(ModBlockEntities.STANDARD_DRAWERS_2.get(), pos, state);
             groupData.setCapabilityProvider(this);
             injectPortableData(groupData);
         }
@@ -84,7 +82,7 @@ public class TileEntityDrawersStandard extends TileEntityDrawers
         private GroupData groupData = new GroupData(4);
 
         public Slot4 (BlockPos pos, BlockState state) {
-            super(ModBlocks.Tile.STANDARD_DRAWERS_4, pos, state);
+            super(ModBlockEntities.STANDARD_DRAWERS_4.get(), pos, state);
             groupData.setCapabilityProvider(this);
             injectPortableData(groupData);
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntitySlave.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntitySlave.java
@@ -6,7 +6,7 @@ import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
 import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.ControllerData;
 import com.jaquadro.minecraft.storagedrawers.capabilities.DrawerItemHandler;
-import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
+import com.jaquadro.minecraft.storagedrawers.core.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
@@ -23,8 +23,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.function.Predicate;
 
-import com.jaquadro.minecraft.storagedrawers.api.capabilities.IItemRepository.ItemRecord;
-
 public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
 {
     private static final int[] drawerSlots = new int[]{0};
@@ -38,7 +36,7 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
     }
 
     public TileEntitySlave (BlockPos pos, BlockState state) {
-        this(ModBlocks.Tile.CONTROLLER_SLAVE, pos, state);
+        this(ModBlockEntities.CONTROLLER_SLAVE.get(), pos, state);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/UpgradeData.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/UpgradeData.java
@@ -179,19 +179,19 @@ public class UpgradeData extends TileDataShim
 
         for (ItemStack stack : upgrades) {
             Item item = stack.getItem();
-            if (item == ModItems.ONE_STACK_UPGRADE)
+            if (item == ModItems.ONE_STACK_UPGRADE.get())
                 hasOneStack = true;
-            else if (item == ModItems.VOID_UPGRADE)
+            else if (item == ModItems.VOID_UPGRADE.get())
                 hasVoid = true;
-            else if (item == ModItems.CONVERSION_UPGRADE)
+            else if (item == ModItems.CONVERSION_UPGRADE.get())
                 hasConversion = true;
-            else if (item == ModItems.CREATIVE_STORAGE_UPGRADE)
+            else if (item == ModItems.CREATIVE_STORAGE_UPGRADE.get())
                 hasUnlimited = true;
-            else if (item == ModItems.CREATIVE_VENDING_UPGRADE)
+            else if (item == ModItems.CREATIVE_VENDING_UPGRADE.get())
                 hasVending = true;
-            else if (item == ModItems.ILLUMINATION_UPGRADE)
+            else if (item == ModItems.ILLUMINATION_UPGRADE.get())
                 hasIllumination = true;
-            else if (item == ModItems.FILL_LEVEL_UPGRADE)
+            else if (item == ModItems.FILL_LEVEL_UPGRADE.get())
                 hasFillLevel = true;
         }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientEventBusSubscriber.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientEventBusSubscriber.java
@@ -1,0 +1,29 @@
+package com.jaquadro.minecraft.storagedrawers.client;
+
+import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
+import com.jaquadro.minecraft.storagedrawers.client.renderer.TileEntityDrawersRenderer;
+import com.jaquadro.minecraft.storagedrawers.core.ModBlockEntities;
+import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
+import net.minecraft.client.renderer.ItemBlockRenderTypes;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.EntityRenderersEvent.RegisterRenderers;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+
+@Mod.EventBusSubscriber(modid = StorageDrawers.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+public class ClientEventBusSubscriber {
+    @SubscribeEvent
+    public static void clientSetup(FMLClientSetupEvent event) {
+        ModBlocks.getDrawers().forEach(blockDrawers -> ItemBlockRenderTypes.setRenderLayer(blockDrawers, RenderType.cutoutMipped()));
+    }
+
+    @SubscribeEvent
+    public static void registerEntityRenderers(RegisterRenderers event) {
+        event.registerBlockEntityRenderer(ModBlockEntities.STANDARD_DRAWERS_1.get(), TileEntityDrawersRenderer::new);
+        event.registerBlockEntityRenderer(ModBlockEntities.STANDARD_DRAWERS_2.get(), TileEntityDrawersRenderer::new);
+        event.registerBlockEntityRenderer(ModBlockEntities.STANDARD_DRAWERS_4.get(), TileEntityDrawersRenderer::new);
+        event.registerBlockEntityRenderer(ModBlockEntities.FRACTIONAL_DRAWERS_3.get(), TileEntityDrawersRenderer::new);
+    }
+}

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
@@ -9,16 +9,23 @@ import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
 import com.mojang.datafixers.util.Either;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
+import com.mojang.math.Vector3f;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.BlockModelShaper;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.block.model.BlockModel;
+import net.minecraft.client.renderer.block.model.ItemOverrides;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.BlockModelRotation;
+import net.minecraft.client.resources.model.Material;
+import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
-import com.mojang.math.Vector3f;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
@@ -36,16 +43,11 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.function.Function;
-
-import net.minecraft.client.renderer.block.model.BakedQuad;
-import net.minecraft.client.renderer.block.model.BlockModel;
-import net.minecraft.client.renderer.block.model.ItemOverrides;
-import net.minecraft.client.resources.model.BakedModel;
-import net.minecraft.client.resources.model.BlockModelRotation;
-import net.minecraft.client.resources.model.Material;
-import net.minecraft.client.resources.model.ModelResourceLocation;
 
 public final class BasicDrawerModel
 {
@@ -110,79 +112,37 @@ public final class BasicDrawerModel
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_count_area_1.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_ind_area_1.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_indbase_area_1.json"),
-                ModBlocks.OAK_FULL_DRAWERS_1,
-                ModBlocks.SPRUCE_FULL_DRAWERS_1,
-                ModBlocks.BIRCH_FULL_DRAWERS_1,
-                ModBlocks.JUNGLE_FULL_DRAWERS_1,
-                ModBlocks.ACACIA_FULL_DRAWERS_1,
-                ModBlocks.DARK_OAK_FULL_DRAWERS_1,
-                ModBlocks.CRIMSON_FULL_DRAWERS_1,
-                ModBlocks.WARPED_FULL_DRAWERS_1);
+                    ModBlocks.getDrawersOfTypeAndSizeAndDepth(BlockDrawers.class, 1, false).toArray(BlockDrawers[]::new));
             populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_icon_area_2.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_count_area_2.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_ind_area_2.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_indbase_area_2.json"),
-                ModBlocks.OAK_FULL_DRAWERS_2,
-                ModBlocks.SPRUCE_FULL_DRAWERS_2,
-                ModBlocks.BIRCH_FULL_DRAWERS_2,
-                ModBlocks.JUNGLE_FULL_DRAWERS_2,
-                ModBlocks.ACACIA_FULL_DRAWERS_2,
-                ModBlocks.DARK_OAK_FULL_DRAWERS_2,
-                ModBlocks.CRIMSON_FULL_DRAWERS_2,
-                ModBlocks.WARPED_FULL_DRAWERS_2);
+                    ModBlocks.getDrawersOfTypeAndSizeAndDepth(BlockDrawers.class, 2, false).toArray(BlockDrawers[]::new));
             populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_icon_area_4.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_count_area_4.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_ind_area_4.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_indbase_area_4.json"),
-                ModBlocks.OAK_FULL_DRAWERS_4,
-                ModBlocks.SPRUCE_FULL_DRAWERS_4,
-                ModBlocks.BIRCH_FULL_DRAWERS_4,
-                ModBlocks.JUNGLE_FULL_DRAWERS_4,
-                ModBlocks.ACACIA_FULL_DRAWERS_4,
-                ModBlocks.DARK_OAK_FULL_DRAWERS_4,
-                ModBlocks.CRIMSON_FULL_DRAWERS_4,
-                ModBlocks.WARPED_FULL_DRAWERS_4);
+                    ModBlocks.getDrawersOfTypeAndSizeAndDepth(BlockDrawers.class, 4, false).toArray(BlockDrawers[]::new));
             populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_icon_area_1.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_count_area_1.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_ind_area_1.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_indbase_area_1.json"),
-                ModBlocks.OAK_HALF_DRAWERS_1,
-                ModBlocks.SPRUCE_HALF_DRAWERS_1,
-                ModBlocks.BIRCH_HALF_DRAWERS_1,
-                ModBlocks.JUNGLE_HALF_DRAWERS_1,
-                ModBlocks.ACACIA_HALF_DRAWERS_1,
-                ModBlocks.DARK_OAK_HALF_DRAWERS_1,
-                ModBlocks.CRIMSON_HALF_DRAWERS_1,
-                ModBlocks.WARPED_HALF_DRAWERS_1);
+                    ModBlocks.getDrawersOfTypeAndSizeAndDepth(BlockDrawers.class, 1, true).toArray(BlockDrawers[]::new));
             populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_icon_area_2.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_count_area_2.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_ind_area_2.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_indbase_area_2.json"),
-                ModBlocks.OAK_HALF_DRAWERS_2,
-                ModBlocks.SPRUCE_HALF_DRAWERS_2,
-                ModBlocks.BIRCH_HALF_DRAWERS_2,
-                ModBlocks.JUNGLE_HALF_DRAWERS_2,
-                ModBlocks.ACACIA_HALF_DRAWERS_2,
-                ModBlocks.DARK_OAK_HALF_DRAWERS_2,
-                ModBlocks.CRIMSON_HALF_DRAWERS_2,
-                ModBlocks.WARPED_HALF_DRAWERS_2);
+                    ModBlocks.getDrawersOfTypeAndSizeAndDepth(BlockDrawers.class, 2, true).toArray(BlockDrawers[]::new));
             populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_icon_area_4.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_count_area_4.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_ind_area_4.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_indbase_area_4.json"),
-                ModBlocks.OAK_HALF_DRAWERS_4,
-                ModBlocks.SPRUCE_HALF_DRAWERS_4,
-                ModBlocks.BIRCH_HALF_DRAWERS_4,
-                ModBlocks.JUNGLE_HALF_DRAWERS_4,
-                ModBlocks.ACACIA_HALF_DRAWERS_4,
-                ModBlocks.DARK_OAK_HALF_DRAWERS_4,
-                ModBlocks.CRIMSON_HALF_DRAWERS_4,
-                ModBlocks.WARPED_HALF_DRAWERS_4);
+                    ModBlocks.getDrawersOfTypeAndSizeAndDepth(BlockDrawers.class, 4, true).toArray(BlockDrawers[]::new));
             populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/comp_drawers_icon_area_3.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/comp_drawers_count_area_3.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/comp_drawers_ind_area_3.json"),
                 new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/comp_drawers_indbase_area_3.json"),
-                ModBlocks.COMPACTING_DRAWERS_3);
+                ModBlocks.getBlocksOfType(BlockCompDrawers.class).toArray(BlockDrawers[]::new));
         }
 
         private static BlockModel getBlockModel (ResourceLocation location) {
@@ -263,55 +223,7 @@ public final class BasicDrawerModel
                 indicatorComp.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/compdrawers_indicator"), rot, texGet));
             }
 
-            replaceBlock(event, ModBlocks.OAK_FULL_DRAWERS_1);
-            replaceBlock(event, ModBlocks.OAK_FULL_DRAWERS_2);
-            replaceBlock(event, ModBlocks.OAK_FULL_DRAWERS_4);
-            replaceBlock(event, ModBlocks.OAK_HALF_DRAWERS_1);
-            replaceBlock(event, ModBlocks.OAK_HALF_DRAWERS_2);
-            replaceBlock(event, ModBlocks.OAK_HALF_DRAWERS_4);
-            replaceBlock(event, ModBlocks.SPRUCE_FULL_DRAWERS_1);
-            replaceBlock(event, ModBlocks.SPRUCE_FULL_DRAWERS_2);
-            replaceBlock(event, ModBlocks.SPRUCE_FULL_DRAWERS_4);
-            replaceBlock(event, ModBlocks.SPRUCE_HALF_DRAWERS_1);
-            replaceBlock(event, ModBlocks.SPRUCE_HALF_DRAWERS_2);
-            replaceBlock(event, ModBlocks.SPRUCE_HALF_DRAWERS_4);
-            replaceBlock(event, ModBlocks.BIRCH_FULL_DRAWERS_1);
-            replaceBlock(event, ModBlocks.BIRCH_FULL_DRAWERS_2);
-            replaceBlock(event, ModBlocks.BIRCH_FULL_DRAWERS_4);
-            replaceBlock(event, ModBlocks.BIRCH_HALF_DRAWERS_1);
-            replaceBlock(event, ModBlocks.BIRCH_HALF_DRAWERS_2);
-            replaceBlock(event, ModBlocks.BIRCH_HALF_DRAWERS_4);
-            replaceBlock(event, ModBlocks.JUNGLE_FULL_DRAWERS_1);
-            replaceBlock(event, ModBlocks.JUNGLE_FULL_DRAWERS_2);
-            replaceBlock(event, ModBlocks.JUNGLE_FULL_DRAWERS_4);
-            replaceBlock(event, ModBlocks.JUNGLE_HALF_DRAWERS_1);
-            replaceBlock(event, ModBlocks.JUNGLE_HALF_DRAWERS_2);
-            replaceBlock(event, ModBlocks.JUNGLE_HALF_DRAWERS_4);
-            replaceBlock(event, ModBlocks.ACACIA_FULL_DRAWERS_1);
-            replaceBlock(event, ModBlocks.ACACIA_FULL_DRAWERS_2);
-            replaceBlock(event, ModBlocks.ACACIA_FULL_DRAWERS_4);
-            replaceBlock(event, ModBlocks.ACACIA_HALF_DRAWERS_1);
-            replaceBlock(event, ModBlocks.ACACIA_HALF_DRAWERS_2);
-            replaceBlock(event, ModBlocks.ACACIA_HALF_DRAWERS_4);
-            replaceBlock(event, ModBlocks.DARK_OAK_FULL_DRAWERS_1);
-            replaceBlock(event, ModBlocks.DARK_OAK_FULL_DRAWERS_2);
-            replaceBlock(event, ModBlocks.DARK_OAK_FULL_DRAWERS_4);
-            replaceBlock(event, ModBlocks.DARK_OAK_HALF_DRAWERS_1);
-            replaceBlock(event, ModBlocks.DARK_OAK_HALF_DRAWERS_2);
-            replaceBlock(event, ModBlocks.DARK_OAK_HALF_DRAWERS_4);
-            replaceBlock(event, ModBlocks.CRIMSON_FULL_DRAWERS_1);
-            replaceBlock(event, ModBlocks.CRIMSON_FULL_DRAWERS_2);
-            replaceBlock(event, ModBlocks.CRIMSON_FULL_DRAWERS_4);
-            replaceBlock(event, ModBlocks.CRIMSON_HALF_DRAWERS_1);
-            replaceBlock(event, ModBlocks.CRIMSON_HALF_DRAWERS_2);
-            replaceBlock(event, ModBlocks.CRIMSON_HALF_DRAWERS_4);
-            replaceBlock(event, ModBlocks.WARPED_FULL_DRAWERS_1);
-            replaceBlock(event, ModBlocks.WARPED_FULL_DRAWERS_2);
-            replaceBlock(event, ModBlocks.WARPED_FULL_DRAWERS_4);
-            replaceBlock(event, ModBlocks.WARPED_HALF_DRAWERS_1);
-            replaceBlock(event, ModBlocks.WARPED_HALF_DRAWERS_2);
-            replaceBlock(event, ModBlocks.WARPED_HALF_DRAWERS_4);
-            replaceBlock(event, ModBlocks.COMPACTING_DRAWERS_3);
+            ModBlocks.getDrawers().forEach(blockDrawers -> replaceBlock(event, blockDrawers));
 
             //event.getModelLoader().getBakedModel(new ResourceLocation(StorageDrawers.MOD_ID, "block/full_drawers_lock"), ModelRotation.X0_Y0, ModelLoader.defaultTextureGetter());
             //event.getModelLoader().getBakedModel(new ResourceLocation(StorageDrawers.MOD_ID, "block/full_drawers_void"), ModelRotation.X0_Y0, ModelLoader.defaultTextureGetter());

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
@@ -75,7 +75,7 @@ public final class BasicDrawerModel
             //if (event.getMap() != Minecraft.getInstance().getTextureMap())
             //    return;
 
-            if (ModBlocks.OAK_FULL_DRAWERS_1 == null) {
+            if (!ModBlocks.OAK_FULL_DRAWERS_1.isPresent()) {
                 StorageDrawers.log.warn("Block objects not set in TextureStitchEvent.  Is your mod environment broken?");
                 return;
             }
@@ -198,7 +198,7 @@ public final class BasicDrawerModel
 
         @SubscribeEvent
         public static void registerModels (ModelBakeEvent event) {
-            if (ModBlocks.OAK_FULL_DRAWERS_1 == null) {
+            if (!ModBlocks.OAK_FULL_DRAWERS_1.isPresent()) {
                 StorageDrawers.log.warn("Block objects not set in ModelBakeEvent.  Is your mod environment broken?");
                 return;
             }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlockEntities.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlockEntities.java
@@ -1,0 +1,50 @@
+package com.jaquadro.minecraft.storagedrawers.core;
+
+import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.*;
+import com.jaquadro.minecraft.storagedrawers.block.tile.*;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.entity.BlockEntityType.BlockEntitySupplier;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public final class ModBlockEntities {
+    public static DeferredRegister<BlockEntityType<?>> BLOCK_ENTITY_REGISTER = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITIES, StorageDrawers.MOD_ID);
+
+    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_1 = BLOCK_ENTITY_REGISTER.register("standard_drawers_1",
+            drawerBlockEntitySupplier(TileEntityDrawersStandard.Slot1::new, BlockStandardDrawers.class, 1));
+    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_2 = BLOCK_ENTITY_REGISTER.register("standard_drawers_2",
+            drawerBlockEntitySupplier(TileEntityDrawersStandard.Slot2::new, BlockStandardDrawers.class, 2));
+    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_4 = BLOCK_ENTITY_REGISTER.register("standard_drawers_4",
+            drawerBlockEntitySupplier(TileEntityDrawersStandard.Slot4::new, BlockStandardDrawers.class, 4));
+    public static final RegistryObject<BlockEntityType<TileEntityDrawersComp>> FRACTIONAL_DRAWERS_3 = BLOCK_ENTITY_REGISTER.register("fractional_drawers_3",
+            drawerBlockEntitySupplier(TileEntityDrawersComp.Slot3::new, BlockCompDrawers.class, 3));
+    public static final RegistryObject<BlockEntityType<TileEntityController>> CONTROLLER = BLOCK_ENTITY_REGISTER.register("controller",
+            blockEntitySupplier(TileEntityController::new, BlockController.class));
+    public static final RegistryObject<BlockEntityType<TileEntitySlave>> CONTROLLER_SLAVE = BLOCK_ENTITY_REGISTER.register("controller_slave",
+            blockEntitySupplier(TileEntitySlave::new, BlockSlave.class));
+
+    private ModBlockEntities() {}
+
+    private static <BE extends TileEntityDrawers, B extends BlockDrawers> Supplier<BlockEntityType<BE>> drawerBlockEntitySupplier(BlockEntitySupplier<BE> blockEntitySupplier, Class<B> drawerBlockClass, int size) {
+        return constructSupplier(blockEntitySupplier, ModBlocks.getDrawersOfTypeAndSize(drawerBlockClass, size));
+    }
+
+    private static <BE extends ChamTileEntity, B extends Block> Supplier<BlockEntityType<BE>> blockEntitySupplier(BlockEntitySupplier<BE> blockEntitySupplier, Class<B> blockClass) {
+        return constructSupplier(blockEntitySupplier, ModBlocks.getBlocksOfType(blockClass));
+    }
+
+    private static <BE extends ChamTileEntity, B extends Block> Supplier<BlockEntityType<BE>> constructSupplier(BlockEntitySupplier<BE> blockEntitySupplier, Stream<B> blockStream) {
+        return () -> BlockEntityType.Builder.of(blockEntitySupplier, blockStream.toArray(Block[]::new)).build(null);
+    }
+
+    public static void register(IEventBus bus) {
+        BLOCK_ENTITY_REGISTER.register(bus);
+    }
+}

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlocks.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlocks.java
@@ -2,471 +2,149 @@ package com.jaquadro.minecraft.storagedrawers.core;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.*;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntitySlave;
-import com.jaquadro.minecraft.storagedrawers.client.renderer.TileEntityDrawersRenderer;
-import com.jaquadro.minecraft.storagedrawers.item.ItemDrawers;
-import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.BlockPos;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.SoundType;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.material.Material;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.client.event.EntityRenderersEvent;
-import net.minecraftforge.client.event.ModelBakeEvent;
-import net.minecraftforge.client.event.ModelRegistryEvent;
-import net.minecraftforge.event.RegistryEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.registries.ObjectHolder;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Material;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
 
-@ObjectHolder(StorageDrawers.MOD_ID)
-public class ModBlocks
+import java.util.stream.Stream;
+
+public final class ModBlocks
 {
-    public static final BlockDrawers
-        OAK_FULL_DRAWERS_1 = null,
-        OAK_FULL_DRAWERS_2 = null,
-        OAK_FULL_DRAWERS_4 = null,
-        OAK_HALF_DRAWERS_1 = null,
-        OAK_HALF_DRAWERS_2 = null,
-        OAK_HALF_DRAWERS_4 = null,
-        SPRUCE_FULL_DRAWERS_1 = null,
-        SPRUCE_FULL_DRAWERS_2 = null,
-        SPRUCE_FULL_DRAWERS_4 = null,
-        SPRUCE_HALF_DRAWERS_1 = null,
-        SPRUCE_HALF_DRAWERS_2 = null,
-        SPRUCE_HALF_DRAWERS_4 = null,
-        BIRCH_FULL_DRAWERS_1 = null,
-        BIRCH_FULL_DRAWERS_2 = null,
-        BIRCH_FULL_DRAWERS_4 = null,
-        BIRCH_HALF_DRAWERS_1 = null,
-        BIRCH_HALF_DRAWERS_2 = null,
-        BIRCH_HALF_DRAWERS_4 = null,
-        JUNGLE_FULL_DRAWERS_1 = null,
-        JUNGLE_FULL_DRAWERS_2 = null,
-        JUNGLE_FULL_DRAWERS_4 = null,
-        JUNGLE_HALF_DRAWERS_1 = null,
-        JUNGLE_HALF_DRAWERS_2 = null,
-        JUNGLE_HALF_DRAWERS_4 = null,
-        ACACIA_FULL_DRAWERS_1 = null,
-        ACACIA_FULL_DRAWERS_2 = null,
-        ACACIA_FULL_DRAWERS_4 = null,
-        ACACIA_HALF_DRAWERS_1 = null,
-        ACACIA_HALF_DRAWERS_2 = null,
-        ACACIA_HALF_DRAWERS_4 = null,
-        DARK_OAK_FULL_DRAWERS_1 = null,
-        DARK_OAK_FULL_DRAWERS_2 = null,
-        DARK_OAK_FULL_DRAWERS_4 = null,
-        DARK_OAK_HALF_DRAWERS_1 = null,
-        DARK_OAK_HALF_DRAWERS_2 = null,
-        DARK_OAK_HALF_DRAWERS_4 = null,
-        CRIMSON_FULL_DRAWERS_1 = null,
-        CRIMSON_FULL_DRAWERS_2 = null,
-        CRIMSON_FULL_DRAWERS_4 = null,
-        CRIMSON_HALF_DRAWERS_1 = null,
-        CRIMSON_HALF_DRAWERS_2 = null,
-        CRIMSON_HALF_DRAWERS_4 = null,
-        WARPED_FULL_DRAWERS_1 = null,
-        WARPED_FULL_DRAWERS_2 = null,
-        WARPED_FULL_DRAWERS_4 = null,
-        WARPED_HALF_DRAWERS_1 = null,
-        WARPED_HALF_DRAWERS_2 = null,
-        WARPED_HALF_DRAWERS_4 = null,
-        COMPACTING_DRAWERS_3 = null;
+    public static final DeferredRegister<Block> BLOCK_REGISTER = DeferredRegister.create(ForgeRegistries.BLOCKS, StorageDrawers.MOD_ID);
 
-    public static final Block
-        OAK_TRIM = null,
-        SPRUCE_TRIM = null,
-        BIRCH_TRIM = null,
-        JUNGLE_TRIM = null,
-        ACACIA_TRIM = null,
-        DARK_OAK_TRIM = null,
-        CRIMSON_TRIM = null,
-        WARPED_TRIM = null;
+    public static final RegistryObject<BlockStandardDrawers>
+        OAK_FULL_DRAWERS_1 = registerDrawerBlock("oak_full_drawers_1", 1, false),
+        OAK_FULL_DRAWERS_2 = registerDrawerBlock("oak_full_drawers_2", 2, false),
+        OAK_FULL_DRAWERS_4 = registerDrawerBlock("oak_full_drawers_4", 4, false),
+        OAK_HALF_DRAWERS_1 = registerDrawerBlock("oak_half_drawers_1", 1, true),
+        OAK_HALF_DRAWERS_2 = registerDrawerBlock("oak_half_drawers_2", 2, true),
+        OAK_HALF_DRAWERS_4 = registerDrawerBlock("oak_half_drawers_4", 4, true),
+        SPRUCE_FULL_DRAWERS_1 = registerDrawerBlock("spruce_full_drawers_1", 1, false),
+        SPRUCE_FULL_DRAWERS_2 = registerDrawerBlock("spruce_full_drawers_2", 2, false),
+        SPRUCE_FULL_DRAWERS_4 = registerDrawerBlock("spruce_full_drawers_4", 4, false),
+        SPRUCE_HALF_DRAWERS_1 = registerDrawerBlock("spruce_half_drawers_1", 1, true),
+        SPRUCE_HALF_DRAWERS_2 = registerDrawerBlock("spruce_half_drawers_2", 2, true),
+        SPRUCE_HALF_DRAWERS_4 = registerDrawerBlock("spruce_half_drawers_4", 4, true),
+        BIRCH_FULL_DRAWERS_1 = registerDrawerBlock("birch_full_drawers_1", 1, false),
+        BIRCH_FULL_DRAWERS_2 = registerDrawerBlock("birch_full_drawers_2", 2, false),
+        BIRCH_FULL_DRAWERS_4 = registerDrawerBlock("birch_full_drawers_4", 4, false),
+        BIRCH_HALF_DRAWERS_1 = registerDrawerBlock("birch_half_drawers_1", 1, true),
+        BIRCH_HALF_DRAWERS_2 = registerDrawerBlock("birch_half_drawers_2", 2, true),
+        BIRCH_HALF_DRAWERS_4 = registerDrawerBlock("birch_half_drawers_4", 4, true),
+        JUNGLE_FULL_DRAWERS_1 = registerDrawerBlock("jungle_full_drawers_1", 1, false),
+        JUNGLE_FULL_DRAWERS_2 = registerDrawerBlock("jungle_full_drawers_2", 2, false),
+        JUNGLE_FULL_DRAWERS_4 = registerDrawerBlock("jungle_full_drawers_4", 4, false),
+        JUNGLE_HALF_DRAWERS_1 = registerDrawerBlock("jungle_half_drawers_1", 1, true),
+        JUNGLE_HALF_DRAWERS_2 = registerDrawerBlock("jungle_half_drawers_2", 2, true),
+        JUNGLE_HALF_DRAWERS_4 = registerDrawerBlock("jungle_half_drawers_4", 4, true),
+        ACACIA_FULL_DRAWERS_1 = registerDrawerBlock("acacia_full_drawers_1", 1, false),
+        ACACIA_FULL_DRAWERS_2 = registerDrawerBlock("acacia_full_drawers_2", 2, false),
+        ACACIA_FULL_DRAWERS_4 = registerDrawerBlock("acacia_full_drawers_4", 4, false),
+        ACACIA_HALF_DRAWERS_1 = registerDrawerBlock("acacia_half_drawers_1", 1, true),
+        ACACIA_HALF_DRAWERS_2 = registerDrawerBlock("acacia_half_drawers_2", 2, true),
+        ACACIA_HALF_DRAWERS_4 = registerDrawerBlock("acacia_half_drawers_4", 4, true),
+        DARK_OAK_FULL_DRAWERS_1 = registerDrawerBlock("dark_oak_full_drawers_1", 1, false),
+        DARK_OAK_FULL_DRAWERS_2 = registerDrawerBlock("dark_oak_full_drawers_2", 2, false),
+        DARK_OAK_FULL_DRAWERS_4 = registerDrawerBlock("dark_oak_full_drawers_4", 4, false),
+        DARK_OAK_HALF_DRAWERS_1 = registerDrawerBlock("dark_oak_half_drawers_1", 1, true),
+        DARK_OAK_HALF_DRAWERS_2 = registerDrawerBlock("dark_oak_half_drawers_2", 2, true),
+        DARK_OAK_HALF_DRAWERS_4 = registerDrawerBlock("dark_oak_half_drawers_4", 4, true),
+        CRIMSON_FULL_DRAWERS_1 = registerDrawerBlock("crimson_full_drawers_1", 1, false),
+        CRIMSON_FULL_DRAWERS_2 = registerDrawerBlock("crimson_full_drawers_2", 2, false),
+        CRIMSON_FULL_DRAWERS_4 = registerDrawerBlock("crimson_full_drawers_4", 4, false),
+        CRIMSON_HALF_DRAWERS_1 = registerDrawerBlock("crimson_half_drawers_1", 1, true),
+        CRIMSON_HALF_DRAWERS_2 = registerDrawerBlock("crimson_half_drawers_2", 2, true),
+        CRIMSON_HALF_DRAWERS_4 = registerDrawerBlock("crimson_half_drawers_4", 4, true),
+        WARPED_FULL_DRAWERS_1 = registerDrawerBlock("warped_full_drawers_1", 1, false),
+        WARPED_FULL_DRAWERS_2 = registerDrawerBlock("warped_full_drawers_2", 2, false),
+        WARPED_FULL_DRAWERS_4 = registerDrawerBlock("warped_full_drawers_4", 4, false),
+        WARPED_HALF_DRAWERS_1 = registerDrawerBlock("warped_half_drawers_1", 1, true),
+        WARPED_HALF_DRAWERS_2 = registerDrawerBlock("warped_half_drawers_2", 2, true),
+        WARPED_HALF_DRAWERS_4 = registerDrawerBlock("warped_half_drawers_4", 4, true);
 
-    public static final BlockController CONTROLLER = null;
-    public static final BlockSlave CONTROLLER_SLAVE = null;
+    public static final RegistryObject<BlockCompDrawers> COMPACTING_DRAWERS_3 = registerCompactingDrawerBlock("compacting_drawers_3");
 
-    @ObjectHolder(StorageDrawers.MOD_ID)
-    public static final class Tile {
-        public static final BlockEntityType<TileEntityDrawersStandard> STANDARD_DRAWERS_1 = null;
-        public static final BlockEntityType<TileEntityDrawersStandard> STANDARD_DRAWERS_2 = null;
-        public static final BlockEntityType<TileEntityDrawersStandard> STANDARD_DRAWERS_4 = null;
-        public static final BlockEntityType<TileEntityDrawersComp> FRACTIONAL_DRAWERS_3 = null;
-        public static final BlockEntityType<TileEntityController> CONTROLLER = null;
-        public static final BlockEntityType<TileEntitySlave> CONTROLLER_SLAVE = null;
-    }
+    public static final RegistryObject<BlockTrim>
+        OAK_TRIM = registerTrimBlock("oak_trim"),
+        SPRUCE_TRIM = registerTrimBlock("spruce_trim"),
+        BIRCH_TRIM = registerTrimBlock("birch_trim"),
+        JUNGLE_TRIM = registerTrimBlock("jungle_trim"),
+        ACACIA_TRIM = registerTrimBlock("acacia_trim"),
+        DARK_OAK_TRIM = registerTrimBlock("dark_oak_trim"),
+        CRIMSON_TRIM = registerTrimBlock("crimson_trim"),
+        WARPED_TRIM = registerTrimBlock("warped_trim");
 
-    @Mod.EventBusSubscriber(modid = StorageDrawers.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
-    public static class Registration
-    {
-        private static List<Block> blockList = new ArrayList<Block>();
+    public static final RegistryObject<BlockController> CONTROLLER = registerControllerBlock("controller");
+    public static final RegistryObject<BlockSlave> CONTROLLER_SLAVE = registerControllerSlaveBlock("controller_slave");
 
-        @SubscribeEvent
-        public static void registerBlocks (RegistryEvent.Register<Block> event) {
-            registerDrawerBlock(event, "oak_full_drawers_1", 1, false);
-            registerDrawerBlock(event, "oak_full_drawers_2", 2, false);
-            registerDrawerBlock(event, "oak_full_drawers_4", 4, false);
-            registerDrawerBlock(event, "oak_half_drawers_1", 1, true);
-            registerDrawerBlock(event, "oak_half_drawers_2", 2, true);
-            registerDrawerBlock(event, "oak_half_drawers_4", 4, true);
-            registerTrimBlock(event, "oak_trim");
-            registerDrawerBlock(event, "spruce_full_drawers_1", 1, false);
-            registerDrawerBlock(event, "spruce_full_drawers_2", 2, false);
-            registerDrawerBlock(event, "spruce_full_drawers_4", 4, false);
-            registerDrawerBlock(event, "spruce_half_drawers_1", 1, true);
-            registerDrawerBlock(event, "spruce_half_drawers_2", 2, true);
-            registerDrawerBlock(event, "spruce_half_drawers_4", 4, true);
-            registerTrimBlock(event, "spruce_trim");
-            registerDrawerBlock(event, "birch_full_drawers_1", 1, false);
-            registerDrawerBlock(event, "birch_full_drawers_2", 2, false);
-            registerDrawerBlock(event, "birch_full_drawers_4", 4, false);
-            registerDrawerBlock(event, "birch_half_drawers_1", 1, true);
-            registerDrawerBlock(event, "birch_half_drawers_2", 2, true);
-            registerDrawerBlock(event, "birch_half_drawers_4", 4, true);
-            registerTrimBlock(event, "birch_trim");
-            registerDrawerBlock(event, "jungle_full_drawers_1", 1, false);
-            registerDrawerBlock(event, "jungle_full_drawers_2", 2, false);
-            registerDrawerBlock(event, "jungle_full_drawers_4", 4, false);
-            registerDrawerBlock(event, "jungle_half_drawers_1", 1, true);
-            registerDrawerBlock(event, "jungle_half_drawers_2", 2, true);
-            registerDrawerBlock(event, "jungle_half_drawers_4", 4, true);
-            registerTrimBlock(event, "jungle_trim");
-            registerDrawerBlock(event, "acacia_full_drawers_1", 1, false);
-            registerDrawerBlock(event, "acacia_full_drawers_2", 2, false);
-            registerDrawerBlock(event, "acacia_full_drawers_4", 4, false);
-            registerDrawerBlock(event, "acacia_half_drawers_1", 1, true);
-            registerDrawerBlock(event, "acacia_half_drawers_2", 2, true);
-            registerDrawerBlock(event, "acacia_half_drawers_4", 4, true);
-            registerTrimBlock(event, "acacia_trim");
-            registerDrawerBlock(event, "dark_oak_full_drawers_1", 1, false);
-            registerDrawerBlock(event, "dark_oak_full_drawers_2", 2, false);
-            registerDrawerBlock(event, "dark_oak_full_drawers_4", 4, false);
-            registerDrawerBlock(event, "dark_oak_half_drawers_1", 1, true);
-            registerDrawerBlock(event, "dark_oak_half_drawers_2", 2, true);
-            registerDrawerBlock(event, "dark_oak_half_drawers_4", 4, true);
-            registerTrimBlock(event, "dark_oak_trim");
-            registerDrawerBlock(event, "crimson_full_drawers_1", 1, false);
-            registerDrawerBlock(event, "crimson_full_drawers_2", 2, false);
-            registerDrawerBlock(event, "crimson_full_drawers_4", 4, false);
-            registerDrawerBlock(event, "crimson_half_drawers_1", 1, true);
-            registerDrawerBlock(event, "crimson_half_drawers_2", 2, true);
-            registerDrawerBlock(event, "crimson_half_drawers_4", 4, true);
-            registerTrimBlock(event, "crimson_trim");
-            registerDrawerBlock(event, "warped_full_drawers_1", 1, false);
-            registerDrawerBlock(event, "warped_full_drawers_2", 2, false);
-            registerDrawerBlock(event, "warped_full_drawers_4", 4, false);
-            registerDrawerBlock(event, "warped_half_drawers_1", 1, true);
-            registerDrawerBlock(event, "warped_half_drawers_2", 2, true);
-            registerDrawerBlock(event, "warped_half_drawers_4", 4, true);
-            registerTrimBlock(event, "warped_trim");
-            registerCompactingDrawerBlock(event, "compacting_drawers_3");
+    private ModBlocks() {}
 
-            registerBlock(event, "controller", new BlockController(BlockBehaviour.Properties.of(Material.STONE)
-                .sound(SoundType.STONE).strength(5)));
-            registerBlock(event, "controller_slave", new BlockSlave(BlockBehaviour.Properties.of(Material.STONE)
-                .sound(SoundType.STONE).strength(5)));
-
-            /*IForgeRegistry<Block> registry = event.getRegistry();
-            ConfigManager config = StorageDrawers.config;
-
-            registry.registerAll(
-                new BlockVariantDrawers("basicdrawers", StorageDrawers.MOD_ID + ".basicDrawers"),
-                new BlockKeyButton("keybutton", StorageDrawers.MOD_ID + ".keyButton")
-            );
-
-            GameRegistry.registerTileEntity(TileEntityDrawersStandard.Legacy.class, StorageDrawers.MOD_ID + ":basicdrawers");
-            GameRegistry.registerTileEntity(TileEntityDrawersStandard.Slot1.class, StorageDrawers.MOD_ID + ":basicdrawers.1");
-            GameRegistry.registerTileEntity(TileEntityDrawersStandard.Slot2.class, StorageDrawers.MOD_ID + ":basicdrawers.2");
-            GameRegistry.registerTileEntity(TileEntityDrawersStandard.Slot4.class, StorageDrawers.MOD_ID + ":basicdrawers.4");
-
-            GameRegistry.registerTileEntity(TileEntityKeyButton.class, StorageDrawers.MOD_ID + ":keybutton");
-
-            if (config.isBlockEnabled("compdrawers")) {
-                registry.register(new BlockCompDrawers("compdrawers", StorageDrawers.MOD_ID + ".compDrawers"));
-                GameRegistry.registerTileEntity(TileEntityDrawersComp.class, StorageDrawers.MOD_ID + ":compdrawers");
-            }
-            if (config.isBlockEnabled("controller")) {
-                registry.register(new BlockController("controller", StorageDrawers.MOD_ID + ".controller"));
-                GameRegistry.registerTileEntity(TileEntityController.class, StorageDrawers.MOD_ID + ":controller");
-            }
-            if (config.isBlockEnabled("controllerSlave")) {
-                registry.register(new BlockSlave("controllerslave", StorageDrawers.MOD_ID + ".controllerSlave"));
-                GameRegistry.registerTileEntity(TileEntitySlave.class, StorageDrawers.MOD_ID + ":controllerslave");
-            }
-            if (config.isBlockEnabled("trim")) {
-                registry.register(new BlockTrim("trim", StorageDrawers.MOD_ID + ".trim"));
-            }
-
-            if (config.cache.enableFramedDrawers) {
-                registry.registerAll(
-                    new BlockFramingTable("framingtable", StorageDrawers.MOD_ID + ".framingTable"),
-                    new BlockDrawersCustom("customdrawers", StorageDrawers.MOD_ID + ".customDrawers"),
-                    new BlockTrimCustom("customtrim", StorageDrawers.MOD_ID + ".customTrim")
-                );
-
-                GameRegistry.registerTileEntity(TileEntityFramingTable.class, StorageDrawers.MOD_ID + ":framingtable");
-                GameRegistry.registerTileEntity(TileEntityTrim.class, StorageDrawers.MOD_ID + ":trim");
-            }*/
-        }
-
-        @SubscribeEvent
-        public static void registerTileEntities(RegistryEvent.Register<BlockEntityType<?>> event) {
-            registerTileEntity(event, "standard_drawers_1", TileEntityDrawersStandard.Slot1::new,
-                OAK_FULL_DRAWERS_1,
-                OAK_HALF_DRAWERS_1,
-                SPRUCE_FULL_DRAWERS_1,
-                SPRUCE_HALF_DRAWERS_1,
-                BIRCH_FULL_DRAWERS_1,
-                BIRCH_HALF_DRAWERS_1,
-                JUNGLE_FULL_DRAWERS_1,
-                JUNGLE_HALF_DRAWERS_1,
-                ACACIA_FULL_DRAWERS_1,
-                ACACIA_HALF_DRAWERS_1,
-                DARK_OAK_FULL_DRAWERS_1,
-                DARK_OAK_HALF_DRAWERS_1,
-                CRIMSON_FULL_DRAWERS_1,
-                CRIMSON_HALF_DRAWERS_1,
-                WARPED_FULL_DRAWERS_1,
-                WARPED_HALF_DRAWERS_1);
-            
-            registerTileEntity(event, "standard_drawers_2", TileEntityDrawersStandard.Slot2::new,
-                OAK_FULL_DRAWERS_2,
-                OAK_HALF_DRAWERS_2,
-                SPRUCE_FULL_DRAWERS_2,
-                SPRUCE_HALF_DRAWERS_2,
-                BIRCH_FULL_DRAWERS_2,
-                BIRCH_HALF_DRAWERS_2,
-                JUNGLE_FULL_DRAWERS_2,
-                JUNGLE_HALF_DRAWERS_2,
-                ACACIA_FULL_DRAWERS_2,
-                ACACIA_HALF_DRAWERS_2,
-                DARK_OAK_FULL_DRAWERS_2,
-                DARK_OAK_HALF_DRAWERS_2,
-                CRIMSON_FULL_DRAWERS_2,
-                CRIMSON_HALF_DRAWERS_2,
-                WARPED_FULL_DRAWERS_2,
-                WARPED_HALF_DRAWERS_2);
-
-            registerTileEntity(event, "standard_drawers_4", TileEntityDrawersStandard.Slot4::new,
-                OAK_FULL_DRAWERS_4,
-                OAK_HALF_DRAWERS_4,
-                SPRUCE_FULL_DRAWERS_4,
-                SPRUCE_HALF_DRAWERS_4,
-                BIRCH_FULL_DRAWERS_4,
-                BIRCH_HALF_DRAWERS_4,
-                JUNGLE_FULL_DRAWERS_4,
-                JUNGLE_HALF_DRAWERS_4,
-                ACACIA_FULL_DRAWERS_4,
-                ACACIA_HALF_DRAWERS_4,
-                DARK_OAK_FULL_DRAWERS_4,
-                DARK_OAK_HALF_DRAWERS_4,
-                CRIMSON_FULL_DRAWERS_4,
-                CRIMSON_HALF_DRAWERS_4,
-                WARPED_FULL_DRAWERS_4,
-                WARPED_HALF_DRAWERS_4);
-
-            registerTileEntity(event, "fractional_drawers_3", TileEntityDrawersComp.Slot3::new, COMPACTING_DRAWERS_3);
-            registerTileEntity(event, "controller", TileEntityController::new, CONTROLLER);
-            registerTileEntity(event, "controller_slave", TileEntitySlave::new, CONTROLLER_SLAVE);
-        }
-
-        private static Block registerDrawerBlock(RegistryEvent.Register<Block> event, String name, int drawerCount, boolean halfDepth) {
-            return registerBlock(event, name, new BlockStandardDrawers(drawerCount, halfDepth, BlockBehaviour.Properties.of(Material.WOOD)
+    private static RegistryObject<BlockStandardDrawers> registerDrawerBlock(String name, int drawerCount, boolean halfDepth) {
+        return BLOCK_REGISTER.register(name, () -> new BlockStandardDrawers(drawerCount, halfDepth, BlockBehaviour.Properties.of(Material.WOOD)
                 .strength(3.0F, 5.0F)
                 .sound(SoundType.WOOD)
-                .isSuffocating(Registration::predFalse)
-                .isRedstoneConductor(Registration::predFalse)));
-        }
+                .isSuffocating(ModBlocks::predFalse)
+                .isRedstoneConductor(ModBlocks::predFalse)));
+    }
 
-        private static Block registerTrimBlock(RegistryEvent.Register<Block> event, String name) {
-            return registerBlock(event, name, new BlockTrim(BlockBehaviour.Properties.of(Material.WOOD)
-                .sound(SoundType.WOOD).strength(5f)));
-        }
-
-        private static Block registerCompactingDrawerBlock(RegistryEvent.Register<Block> event, String name) {
-            return registerBlock(event, name, new BlockCompDrawers(BlockBehaviour.Properties.of(Material.STONE)
+    private static RegistryObject<BlockCompDrawers> registerCompactingDrawerBlock(String name) {
+        return  BLOCK_REGISTER.register(name, () -> new BlockCompDrawers(BlockBehaviour.Properties.of(Material.STONE)
                 .sound(SoundType.STONE).strength(10f)
-                .isSuffocating(Registration::predFalse)
-                .isRedstoneConductor(Registration::predFalse)));
-        }
+                .isSuffocating(ModBlocks::predFalse)
+                .isRedstoneConductor(ModBlocks::predFalse)));
+    }
 
-        private static Block registerBlock(RegistryEvent.Register<Block> event, String name, Block block) {
-            return registerBlock(event, name, block, blockList);
-        }
+    private static RegistryObject<BlockTrim> registerTrimBlock(String name) {
+        return BLOCK_REGISTER.register(name, () -> new BlockTrim(BlockBehaviour.Properties.of(Material.WOOD)
+                .sound(SoundType.WOOD).strength(5f)));
+    }
 
-        private static Block registerBlock(RegistryEvent.Register<Block> event, String name, Block block, List<Block> group) {
-            block.setRegistryName(name);
-            event.getRegistry().register(block);
-            group.add(block);
+    private static RegistryObject<BlockController> registerControllerBlock(String name) {
+        return  BLOCK_REGISTER.register(name, () -> new BlockController(BlockBehaviour.Properties.of(Material.WOOD)
+                .sound(SoundType.STONE).strength(5f)));
+    }
 
-            return block;
-        }
+    private static RegistryObject<BlockSlave> registerControllerSlaveBlock(String name) {
+        return  BLOCK_REGISTER.register(name, () -> new BlockSlave(BlockBehaviour.Properties.of(Material.WOOD)
+                .sound(SoundType.STONE).strength(5f)));
+    }
 
-        private static <T extends BlockEntity> void registerTileEntity(RegistryEvent.Register<BlockEntityType<?>> event, String name, BlockEntityType.BlockEntitySupplier<? extends T> factory, Block... blocks) {
-            event.getRegistry().register(BlockEntityType.Builder.of(factory, blocks)
-                .build(null).setRegistryName(new ResourceLocation(StorageDrawers.MOD_ID, name)));
-        }
+    public static void register(IEventBus bus) {
+        BLOCK_REGISTER.register(bus);
+    }
 
-        @SubscribeEvent
-        public static void registerItems (RegistryEvent.Register<Item> event) {
-            for (Block block : blockList) {
-                BlockItem itemBlock = null;
-                if (block instanceof BlockDrawers)
-                    itemBlock = new ItemDrawers(block, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS));
-                else
-                    itemBlock = new BlockItem(block, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS));
+    public static <T extends Block> Stream<T> getBlocksOfType(Class<T> blockClass) {
+        return BLOCK_REGISTER.getEntries()
+                .stream()
+                .filter(RegistryObject::isPresent)
+                .map(RegistryObject::get)
+                .filter(blockClass::isInstance)
+                .map(blockClass::cast);
+    }
 
-                itemBlock.setRegistryName(block.getRegistryName());
-                event.getRegistry().register(itemBlock);
-            }
+    public static Stream<BlockDrawers> getDrawers() {
+        return getBlocksOfType(BlockDrawers.class);
+    }
 
-            /*IForgeRegistry<Item> registry = event.getRegistry();
-            ConfigManager config = StorageDrawers.config;
+    public static <T extends BlockDrawers> Stream<T> getDrawersOfTypeAndSize(Class<T> drawerClass, int size) {
+        return getBlocksOfType(drawerClass)
+                .filter(blockStandardDrawers -> blockStandardDrawers.getDrawerCount() == size);
+    }
 
-            registry.registerAll(
-                new ItemBasicDrawers(basicDrawers).setRegistryName(basicDrawers.getRegistryName()),
-                new ItemKeyButton(keyButton).setRegistryName(keyButton.getRegistryName())
-            );
+    public static <T extends BlockDrawers> Stream<T> getDrawersOfTypeAndSizeAndDepth(Class<T> drawerClass, int size, boolean halfDepth) {
+        return getDrawersOfTypeAndSize(drawerClass, size)
+                .filter(blockStandardDrawers -> blockStandardDrawers.isHalfDepth() == halfDepth);
+    }
 
-            if (config.isBlockEnabled("compdrawers"))
-                registry.register(new ItemCompDrawers(compDrawers).setRegistryName(compDrawers.getRegistryName()));
-            if (config.isBlockEnabled("controller"))
-                registry.register(new ItemController(controller).setRegistryName(controller.getRegistryName()));
-            if (config.isBlockEnabled("controllerSlave"))
-                registry.register(new ItemBlock(controllerSlave).setRegistryName(controllerSlave.getRegistryName()));
-            if (config.isBlockEnabled("trim"))
-                registry.register(new ItemTrim(trim).setRegistryName(trim.getRegistryName()));
-
-            if (config.cache.enableFramedDrawers) {
-                registry.registerAll(
-                    new ItemFramingTable(framingTable).setRegistryName(framingTable.getRegistryName()),
-                    new ItemCustomDrawers(customDrawers).setRegistryName(customDrawers.getRegistryName()),
-                    new ItemCustomTrim(customTrim).setRegistryName(customTrim.getRegistryName())
-                );
-            }
-
-            for (String key : new String[] { "drawerBasic" })
-                OreDictionary.registerOre(key, new ItemStack(basicDrawers, 1, OreDictionary.WILDCARD_VALUE));
-            for (String key : new String[] { "drawerTrim" })
-                OreDictionary.registerOre(key, new ItemStack(trim, 1, OreDictionary.WILDCARD_VALUE));*/
-        }
-
-        /*
-        @SubscribeEvent
-        public static void registerRecipes (RegistryEvent.Register<IRecipe> event) {
-            IForgeRegistry<IRecipe> registry = event.getRegistry();
-            ConfigManager config = StorageDrawers.config;
-
-            for (BlockPlanks.EnumType material : BlockPlanks.EnumType.values()) {
-                ItemStack pl = new ItemStack(Blocks.PLANKS, 1, material.getMetadata());
-                ItemStack sl = new ItemStack(Blocks.WOODEN_SLAB, 1, material.getMetadata());
-
-                if (config.isBlockEnabled(EnumBasicDrawer.FULL1.getUnlocalizedName())) {
-                    ItemStack result = makeBasicDrawerItemStack(EnumBasicDrawer.FULL1, material.getName(), config.getBlockRecipeOutput(EnumBasicDrawer.FULL1.getUnlocalizedName()));
-                    registry.register(new ShapedOreRecipe(EMPTY_GROUP, result, "xxx", " y ", "xxx", 'x', new ItemStack(Blocks.PLANKS, 1, material.getMetadata()), 'y', "chestWood")
-                        .setRegistryName(result.getItem().getRegistryName() + "_" + EnumBasicDrawer.FULL1.getUnlocalizedName() + "_" + material.toString()));
-                }
-                if (config.isBlockEnabled(EnumBasicDrawer.FULL2.getUnlocalizedName())) {
-                    ItemStack result = makeBasicDrawerItemStack(EnumBasicDrawer.FULL2, material.getName(), config.getBlockRecipeOutput(EnumBasicDrawer.FULL2.getUnlocalizedName()));
-                    registry.register(new ShapedOreRecipe(EMPTY_GROUP, result, "xyx", "xxx", "xyx", 'x', new ItemStack(Blocks.PLANKS, 1, material.getMetadata()), 'y', "chestWood")
-                        .setRegistryName(result.getItem().getRegistryName() + "_" + EnumBasicDrawer.FULL2.getUnlocalizedName() + "_" + material.toString()));
-                }
-                if (config.isBlockEnabled(EnumBasicDrawer.FULL4.getUnlocalizedName())) {
-                    ItemStack result = makeBasicDrawerItemStack(EnumBasicDrawer.FULL4, material.getName(), config.getBlockRecipeOutput(EnumBasicDrawer.FULL4.getUnlocalizedName()));
-                    registry.register(new ShapedOreRecipe(EMPTY_GROUP, result, "yxy", "xxx", "yxy", 'x', new ItemStack(Blocks.PLANKS, 1, material.getMetadata()), 'y', "chestWood")
-                        .setRegistryName(result.getItem().getRegistryName() + "_" + EnumBasicDrawer.FULL4.getUnlocalizedName() + "_" + material.toString()));
-                }
-                if (config.isBlockEnabled(EnumBasicDrawer.HALF2.getUnlocalizedName())) {
-                    ItemStack result = makeBasicDrawerItemStack(EnumBasicDrawer.HALF2, material.getName(), config.getBlockRecipeOutput(EnumBasicDrawer.HALF2.getUnlocalizedName()));
-                    registry.register(new ShapedOreRecipe(EMPTY_GROUP, result, "xyx", "xxx", "xyx", 'x', new ItemStack(Blocks.WOODEN_SLAB, 1, material.getMetadata()), 'y', "chestWood")
-                        .setRegistryName(result.getItem().getRegistryName() + "_" + EnumBasicDrawer.HALF2.getUnlocalizedName() + "_" + material.toString()));
-                }
-                if (config.isBlockEnabled(EnumBasicDrawer.HALF4.getUnlocalizedName())) {
-                    ItemStack result = makeBasicDrawerItemStack(EnumBasicDrawer.HALF4, material.getName(), config.getBlockRecipeOutput(EnumBasicDrawer.HALF4.getUnlocalizedName()));
-                    registry.register(new ShapedOreRecipe(EMPTY_GROUP, result, "yxy", "xxx", "yxy", 'x', new ItemStack(Blocks.WOODEN_SLAB, 1, material.getMetadata()), 'y', "chestWood")
-                        .setRegistryName(result.getItem().getRegistryName() + "_" + EnumBasicDrawer.HALF4.getUnlocalizedName() + "_" + material.toString()));
-                }
-                if (config.isBlockEnabled("trim")) {
-                    ItemStack result = new ItemStack(ModBlocks.trim, config.getBlockRecipeOutput("trim"), material.getMetadata());
-                    registry.register(new ShapedOreRecipe(EMPTY_GROUP, result, "xyx", "yyy", "xyx", 'x', "stickWood", 'y', new ItemStack(Blocks.PLANKS, 1, material.getMetadata()))
-                        .setRegistryName(result.getItem().getRegistryName() + "_" + material.toString()));
-                }
-            }
-        }*/
-
-        @SubscribeEvent
-        @OnlyIn(Dist.CLIENT)
-        public static void onRegisterRenderers (final EntityRenderersEvent.RegisterRenderers event) {
-            event.registerBlockEntityRenderer(Tile.STANDARD_DRAWERS_1, TileEntityDrawersRenderer::new);
-            event.registerBlockEntityRenderer(Tile.STANDARD_DRAWERS_2, TileEntityDrawersRenderer::new);
-            event.registerBlockEntityRenderer(Tile.STANDARD_DRAWERS_4, TileEntityDrawersRenderer::new);
-            event.registerBlockEntityRenderer(Tile.FRACTIONAL_DRAWERS_3, TileEntityDrawersRenderer::new);
-        }
-
-        @OnlyIn(Dist.CLIENT)
-        public static void bindRenderTypes () {
-            for (Block block : blockList) {
-                if (block instanceof BlockDrawers)
-                    ItemBlockRenderTypes.setRenderLayer(block, RenderType.cutoutMipped());
-            }
-        }
-
-        //@SubscribeEvent
-        //@SideOnly(Side.CLIENT)
-        //public static void registerModels (ModelBakeEvent event) {
-            //event.getModelRegistry().
-            /*if (basicDrawers != null)
-                basicDrawers.initDynamic();
-            if (compDrawers != null)
-                compDrawers.initDynamic();
-            if (customDrawers != null)
-                customDrawers.initDynamic();
-
-            ClientRegistry.bindTileEntitySpecialRenderer(TileEntityDrawersStandard.class, new TileEntityDrawersRenderer());
-            ClientRegistry.bindTileEntitySpecialRenderer(TileEntityDrawersComp.class, new TileEntityDrawersRenderer());
-            ClientRegistry.bindTileEntitySpecialRenderer(TileEntityFramingTable.class, new TileEntityFramingRenderer());
-
-            ModelRegistry modelRegistry = Chameleon.instance.modelRegistry;
-
-            if (basicDrawers != null)
-                modelRegistry.registerModel(new BasicDrawerModel.Register());
-            if (compDrawers != null)
-                modelRegistry.registerModel(new CompDrawerModel.Register());
-            if (customDrawers != null) {
-                modelRegistry.registerModel(new FramingTableModel.Register());
-                modelRegistry.registerModel(new CustomDrawerModel.Register());
-                modelRegistry.registerModel(new CustomTrimModel.Register());
-            }
-
-            modelRegistry.registerItemVariants(trim);
-            modelRegistry.registerItemVariants(controller);
-            modelRegistry.registerItemVariants(controllerSlave);
-            modelRegistry.registerItemVariants(keyButton);*/
-        //}
-
-        private static boolean predFalse (BlockState p_235436_0_, BlockGetter p_235436_1_, BlockPos p_235436_2_) {
-            return false;
-        }
+    private static boolean predFalse (BlockState blockState, BlockGetter blockGetter, BlockPos blockPos) {
+        return false;
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModItemGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModItemGroup.java
@@ -12,7 +12,7 @@ public class ModItemGroup
         @Override
         @Nonnull
         public ItemStack makeIcon () {
-            return new ItemStack(ModBlocks.OAK_FULL_DRAWERS_2);
+            return new ItemStack(ModBlocks.OAK_FULL_DRAWERS_2.get());
         }
     });
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModItems.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModItems.java
@@ -1,148 +1,54 @@
 package com.jaquadro.minecraft.storagedrawers.core;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
 import com.jaquadro.minecraft.storagedrawers.item.*;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.event.RegistryEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.registries.ObjectHolder;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
 
-@ObjectHolder(StorageDrawers.MOD_ID)
-public class ModItems
+public final class ModItems
 {
-    public static final Item
-        OBSIDIAN_STORAGE_UPGRADE = null,
-        IRON_STORAGE_UPGRADE = null,
-        GOLD_STORAGE_UPGRADE = null,
-        DIAMOND_STORAGE_UPGRADE = null,
-        EMERALD_STORAGE_UPGRADE = null,
-        ONE_STACK_UPGRADE = null,
-        VOID_UPGRADE = null,
-        CREATIVE_STORAGE_UPGRADE = null,
-        CREATIVE_VENDING_UPGRADE = null,
-        CONVERSION_UPGRADE = null,
-        REDSTONE_UPGRADE = null,
-        MIN_REDSTONE_UPGRADE = null,
-        MAX_REDSTONE_UPGRADE = null,
-        ILLUMINATION_UPGRADE = null,
-        FILL_LEVEL_UPGRADE = null,
-        UPGRADE_TEMPLATE = null,
-        DRAWER_KEY = null,
-        QUANTIFY_KEY = null,
-        SHROUD_KEY = null;
+    public static final DeferredRegister<Item> ITEM_REGISTER = DeferredRegister.create(ForgeRegistries.ITEMS, StorageDrawers.MOD_ID);
 
-    /*@ObjectHolder(StorageDrawers.MOD_ID + ":upgrade_template")
-    public static Item upgradeTemplate;
-    @ObjectHolder(StorageDrawers.MOD_ID + ":upgrade_storage")
-    public static ItemUpgradeStorage upgradeStorage;
-    @ObjectHolder(StorageDrawers.MOD_ID + ":upgrade_one_stack")
-    public static ItemUpgrade upgradeOneStack;
-    @ObjectHolder(StorageDrawers.MOD_ID + ":upgrade_status")
-    public static ItemUpgradeStatus upgradeStatus;
-    @ObjectHolder(StorageDrawers.MOD_ID + ":drawer_key")
-    public static ItemDrawerKey drawerKey;
-    @ObjectHolder(StorageDrawers.MOD_ID + ":upgrade_void")
-    public static ItemUpgrade upgradeVoid;
-    @ObjectHolder(StorageDrawers.MOD_ID + ":upgrade_conversion")
-    public static ItemUpgrade upgradeConversion;
-    @ObjectHolder(StorageDrawers.MOD_ID + ":upgrade_creative")
-    public static ItemUpgradeCreative upgradeCreative;
-    @ObjectHolder(StorageDrawers.MOD_ID + ":upgrade_redstone")
-    public static ItemUpgradeRedstone upgradeRedstone;
-    @ObjectHolder(StorageDrawers.MOD_ID + ":shroud_key")
-    public static ItemShroudKey shroudKey;
-    @ObjectHolder(StorageDrawers.MOD_ID + ":personal_key")
-    public static ItemPersonalKey personalKey;
-    @ObjectHolder(StorageDrawers.MOD_ID + ":quantify_key")
-    public static ItemQuantifyKey quantifyKey;
-    @ObjectHolder(StorageDrawers.MOD_ID + ":tape")
-    public static ItemTape tape;*/
+    public static final RegistryObject<Item>
+        OBSIDIAN_STORAGE_UPGRADE = ITEM_REGISTER.register("obsidian_storage_upgrade", () -> new ItemUpgradeStorage(EnumUpgradeStorage.OBSIDIAN, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        IRON_STORAGE_UPGRADE = ITEM_REGISTER.register("iron_storage_upgrade", () -> new ItemUpgradeStorage(EnumUpgradeStorage.IRON, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        GOLD_STORAGE_UPGRADE = ITEM_REGISTER.register("gold_storage_upgrade", () -> new ItemUpgradeStorage(EnumUpgradeStorage.GOLD, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        DIAMOND_STORAGE_UPGRADE = ITEM_REGISTER.register("diamond_storage_upgrade", () -> new ItemUpgradeStorage(EnumUpgradeStorage.DIAMOND, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        EMERALD_STORAGE_UPGRADE = ITEM_REGISTER.register("emerald_storage_upgrade", () -> new ItemUpgradeStorage(EnumUpgradeStorage.EMERALD, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        ONE_STACK_UPGRADE = ITEM_REGISTER.register("one_stack_upgrade", () -> new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        VOID_UPGRADE = ITEM_REGISTER.register("void_upgrade", () -> new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        CREATIVE_STORAGE_UPGRADE = ITEM_REGISTER.register("creative_storage_upgrade", () -> new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        CREATIVE_VENDING_UPGRADE = ITEM_REGISTER.register("creative_vending_upgrade", () -> new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        CONVERSION_UPGRADE = ITEM_REGISTER.register("conversion_upgrade", () -> new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        REDSTONE_UPGRADE = ITEM_REGISTER.register("redstone_upgrade", () -> new ItemUpgradeRedstone(EnumUpgradeRedstone.COMBINED, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        MIN_REDSTONE_UPGRADE = ITEM_REGISTER.register("min_redstone_upgrade", () -> new ItemUpgradeRedstone(EnumUpgradeRedstone.MIN, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        MAX_REDSTONE_UPGRADE = ITEM_REGISTER.register("max_redstone_upgrade", () -> new ItemUpgradeRedstone(EnumUpgradeRedstone.MAX, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        ILLUMINATION_UPGRADE = ITEM_REGISTER.register("illumination_upgrade", () -> new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        FILL_LEVEL_UPGRADE = ITEM_REGISTER.register("fill_level_upgrade", () -> new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        UPGRADE_TEMPLATE = ITEM_REGISTER.register("upgrade_template", () -> new Item(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        DRAWER_KEY = ITEM_REGISTER.register("drawer_key", () -> new ItemDrawerKey(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        QUANTIFY_KEY = ITEM_REGISTER.register("quantify_key", () -> new ItemQuantifyKey(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS))),
+        SHROUD_KEY = ITEM_REGISTER.register("shroud_key", () -> new ItemShroudKey(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
 
-    @Mod.EventBusSubscriber(modid = StorageDrawers.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
-    public static class Registration
-    {
-        @SubscribeEvent
-        public static void registerItems (RegistryEvent.Register<Item> event) {
-            register(event, "obsidian_storage_upgrade", new ItemUpgradeStorage(EnumUpgradeStorage.OBSIDIAN, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "iron_storage_upgrade", new ItemUpgradeStorage(EnumUpgradeStorage.IRON, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "gold_storage_upgrade", new ItemUpgradeStorage(EnumUpgradeStorage.GOLD, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "diamond_storage_upgrade", new ItemUpgradeStorage(EnumUpgradeStorage.DIAMOND, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "emerald_storage_upgrade", new ItemUpgradeStorage(EnumUpgradeStorage.EMERALD, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "one_stack_upgrade", new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "void_upgrade", new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "creative_storage_upgrade", new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "creative_vending_upgrade", new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "conversion_upgrade", new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "redstone_upgrade", new ItemUpgradeRedstone(EnumUpgradeRedstone.COMBINED, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "min_redstone_upgrade", new ItemUpgradeRedstone(EnumUpgradeRedstone.MIN, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "max_redstone_upgrade", new ItemUpgradeRedstone(EnumUpgradeRedstone.MAX, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "illumination_upgrade", new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "fill_level_upgrade", new ItemUpgrade(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "upgrade_template", new Item(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "drawer_key", new ItemDrawerKey(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "quantify_key", new ItemQuantifyKey(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
-            register(event, "shroud_key", new ItemShroudKey(new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS)));
+    private ModItems() {}
 
-            //IForgeRegistry<Item> itemRegistry = event.getRegistry();
-            //ConfigManager config = StorageDrawers.config;
-
-            /*itemRegistry.register(new Item().setUnlocalizedName(makeName("upgradeTemplate")).setRegistryName("upgrade_template").setCreativeTab(ModCreativeTabs.tabStorageDrawers));
-
-            if (config.cache.enableStorageUpgrades) {
-                itemRegistry.register(new ItemUpgradeStorage("upgrade_storage", makeName("upgradeStorage")));
-                itemRegistry.register(new ItemUpgrade("upgrade_one_stack", makeName("upgradeOneStack")));
-            }
-
-            if (StorageDrawers.config.cache.enableIndicatorUpgrades)
-                itemRegistry.register(new ItemUpgradeStatus("upgrade_status", makeName("upgradeStatus")));
-            if (StorageDrawers.config.cache.enableVoidUpgrades)
-                itemRegistry.register(new ItemUpgrade("upgrade_void", makeName("upgradeVoid")));
-            if (StorageDrawers.config.cache.enableItemConversion)
-                itemRegistry.register(new ItemUpgrade("upgrade_conversion", makeName("upgradeConversion")));
-            if (StorageDrawers.config.cache.enableCreativeUpgrades)
-                itemRegistry.register(new ItemUpgradeCreative("upgrade_creative", makeName("upgradeCreative")));
-            if (StorageDrawers.config.cache.enableRedstoneUpgrades)
-                itemRegistry.register(new ItemUpgradeRedstone("upgrade_redstone", makeName("upgradeRedstone")));
-            if (StorageDrawers.config.cache.enableLockUpgrades)
-                itemRegistry.register(new ItemDrawerKey("drawer_key", makeName("drawerKey")));
-            if (StorageDrawers.config.cache.enableShroudUpgrades)
-                itemRegistry.register(new ItemShroudKey("shroud_key", makeName("shroudKey")));
-            if (StorageDrawers.config.cache.enablePersonalUpgrades)
-                itemRegistry.register(new ItemPersonalKey("personal_key", makeName("personalKey")));
-            if (StorageDrawers.config.cache.enableQuantifiableUpgrades)
-                itemRegistry.register(new ItemQuantifyKey("quantify_key", makeName("quantifyKey")));
-            if (StorageDrawers.config.cache.enableTape)
-                itemRegistry.register(new ItemTape("tape", makeName("tape")));*/
+    public static void register(IEventBus bus) {
+        for (RegistryObject<Block> ro : ModBlocks.BLOCK_REGISTER.getEntries()) {
+            ITEM_REGISTER.register(ro.getId().getPath(), () -> {
+                Block block = ro.get();
+                if (block instanceof BlockDrawers) {
+                    return new ItemDrawers(ro.get(), new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS));
+                } else {
+                    return new BlockItem(ro.get(), new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS));
+                }
+            });
         }
-
-        private static void register(RegistryEvent.Register<Item> event, String key, Item item) {
-            item.setRegistryName(new ResourceLocation(StorageDrawers.MOD_ID, key));
-            event.getRegistry().register(item);
-        }
-
-        /*@SubscribeEvent
-        public static void registerModels (ModelRegistryEvent event) {
-            ModelRegistry modelRegistry = Chameleon.instance.modelRegistry;
-
-            modelRegistry.registerItemVariants(upgradeTemplate);
-            modelRegistry.registerItemVariants(upgradeVoid);
-            modelRegistry.registerItemVariants(upgradeConversion);
-            modelRegistry.registerItemVariants(tape);
-            modelRegistry.registerItemVariants(drawerKey);
-            modelRegistry.registerItemVariants(shroudKey);
-            modelRegistry.registerItemVariants(personalKey);
-            modelRegistry.registerItemVariants(quantifyKey);
-            modelRegistry.registerItemVariants(upgradeStorage);
-            modelRegistry.registerItemVariants(upgradeOneStack);
-            modelRegistry.registerItemVariants(upgradeStatus);
-            modelRegistry.registerItemVariants(upgradeCreative);
-            modelRegistry.registerItemVariants(upgradeRedstone);
-        }*/
+        ITEM_REGISTER.register(bus);
     }
-
-    /*public static String makeName (String name) {
-        return StorageDrawers.MOD_ID.toLowerCase() + "." + name;
-    }*/
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModItems.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModItems.java
@@ -43,9 +43,9 @@ public final class ModItems
             ITEM_REGISTER.register(ro.getId().getPath(), () -> {
                 Block block = ro.get();
                 if (block instanceof BlockDrawers) {
-                    return new ItemDrawers(ro.get(), new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS));
+                    return new ItemDrawers(block, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS));
                 } else {
-                    return new BlockItem(ro.get(), new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS));
+                    return new BlockItem(block, new Item.Properties().tab(ModItemGroup.STORAGE_DRAWERS));
                 }
             });
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/recipe/AddUpgradeRecipe.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/recipe/AddUpgradeRecipe.java
@@ -1,23 +1,21 @@
 package com.jaquadro.minecraft.storagedrawers.core.recipe;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.UpgradeData;
 import com.jaquadro.minecraft.storagedrawers.core.ModItems;
 import com.jaquadro.minecraft.storagedrawers.item.ItemDrawers;
 import com.jaquadro.minecraft.storagedrawers.item.ItemUpgrade;
-
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CustomRecipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.Level;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 
 public class AddUpgradeRecipe extends CustomRecipe
 {
@@ -83,7 +81,7 @@ public class AddUpgradeRecipe extends CustomRecipe
             ret.data.read(ret.drawer.getTag().getCompound("tile"));
 
         for (ItemStack upgrade : ret.upgrades) {
-            if (upgrade.getItem() == ModItems.ONE_STACK_UPGRADE)
+            if (upgrade.getItem() == ModItems.ONE_STACK_UPGRADE.get())
                 return null; //I don't want to dig into finding the stack sizes to check if we can downgrade. So just don't allow this one >.>
             if (!ret.data.hasEmptySlot() || !ret.data.canAddUpgrade(upgrade))
                 return null;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/SlotUpgrade.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/SlotUpgrade.java
@@ -37,7 +37,7 @@ public class SlotUpgrade extends Slot
             }
 
             if (player != null && !player.isCreative()) {
-                if (stack.getItem() == ModItems.CREATIVE_STORAGE_UPGRADE || stack.getItem() == ModItems.CREATIVE_VENDING_UPGRADE)
+                if (stack.getItem() == ModItems.CREATIVE_STORAGE_UPGRADE.get() || stack.getItem() == ModItems.CREATIVE_VENDING_UPGRADE.get())
                     return false;
             }
         }


### PR DESCRIPTION
This PR encapsulates the process of moving object registration from ObjectHolders to DeferredRegisters, which is the preferred registration method for Forge.

Additionally:

- Blocks, Items, BlockEntityTypes and RenderTypes/BERs registrations were each moved to a separate file.
- Some of the Item, BlockEntityType and BasicDrawerModel operations are now done in bulk, which greatly reduces code duplication.