### PR TITLE
Improving item label rendering performance

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
@@ -10,6 +10,7 @@ import com.jaquadro.minecraft.storagedrawers.core.*;
 import com.jaquadro.minecraft.storagedrawers.core.recipe.AddUpgradeRecipe;
 import com.jaquadro.minecraft.storagedrawers.integration.TheOneProbe;
 import com.jaquadro.minecraft.storagedrawers.network.MessageHandler;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.SimpleRecipeSerializer;
 import net.minecraftforge.api.distmarker.Dist;
@@ -116,5 +117,9 @@ public class StorageDrawers
         CapabilityDrawerGroup.register(event);
         CapabilityItemRepository.register(event);
         CapabilityDrawerAttributes.register(event);
+    }
+
+    public static ResourceLocation rl(String path) {
+        return new ResourceLocation(MOD_ID, path);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientEventBusSubscriber.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientEventBusSubscriber.java
@@ -21,9 +21,6 @@ public class ClientEventBusSubscriber {
 
     @SubscribeEvent
     public static void registerEntityRenderers(RegisterRenderers event) {
-        event.registerBlockEntityRenderer(ModBlockEntities.STANDARD_DRAWERS_1.get(), TileEntityDrawersRenderer::new);
-        event.registerBlockEntityRenderer(ModBlockEntities.STANDARD_DRAWERS_2.get(), TileEntityDrawersRenderer::new);
-        event.registerBlockEntityRenderer(ModBlockEntities.STANDARD_DRAWERS_4.get(), TileEntityDrawersRenderer::new);
-        event.registerBlockEntityRenderer(ModBlockEntities.FRACTIONAL_DRAWERS_3.get(), TileEntityDrawersRenderer::new);
+        ModBlockEntities.getBlockEntityTypesWithRenderers().forEach(ro -> event.registerBlockEntityRenderer(ro.get(), TileEntityDrawersRenderer::new));
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
@@ -80,13 +80,13 @@ public final class BasicDrawerModel
                 return;
             }
 
-            loadUnbakedModel(event, new ResourceLocation(StorageDrawers.MOD_ID, "models/block/full_drawers_lock.json"));
-            loadUnbakedModel(event, new ResourceLocation(StorageDrawers.MOD_ID, "models/block/full_drawers_void.json"));
-            loadUnbakedModel(event, new ResourceLocation(StorageDrawers.MOD_ID, "models/block/full_drawers_shroud.json"));
-            loadUnbakedModel(event, new ResourceLocation(StorageDrawers.MOD_ID, "models/block/compdrawers_indicator.json"));
-            loadUnbakedModel(event, new ResourceLocation(StorageDrawers.MOD_ID, "models/block/full_drawers_indicator_1.json"));
-            loadUnbakedModel(event, new ResourceLocation(StorageDrawers.MOD_ID, "models/block/full_drawers_indicator_2.json"));
-            loadUnbakedModel(event, new ResourceLocation(StorageDrawers.MOD_ID, "models/block/full_drawers_indicator_4.json"));
+            loadUnbakedModel(event, StorageDrawers.rl("models/block/full_drawers_lock.json"));
+            loadUnbakedModel(event, StorageDrawers.rl("models/block/full_drawers_void.json"));
+            loadUnbakedModel(event, StorageDrawers.rl("models/block/full_drawers_shroud.json"));
+            loadUnbakedModel(event, StorageDrawers.rl("models/block/compdrawers_indicator.json"));
+            loadUnbakedModel(event, StorageDrawers.rl("models/block/full_drawers_indicator_1.json"));
+            loadUnbakedModel(event, StorageDrawers.rl("models/block/full_drawers_indicator_2.json"));
+            loadUnbakedModel(event, StorageDrawers.rl("models/block/full_drawers_indicator_4.json"));
 
             loadGeometryData();
         }
@@ -108,40 +108,40 @@ public final class BasicDrawerModel
 
             geometryDataLoaded = true;
 
-            populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_icon_area_1.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_count_area_1.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_ind_area_1.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_indbase_area_1.json"),
+            populateGeometryData(StorageDrawers.rl("models/block/geometry/full_drawers_icon_area_1.json"),
+                StorageDrawers.rl("models/block/geometry/full_drawers_count_area_1.json"),
+                StorageDrawers.rl("models/block/geometry/full_drawers_ind_area_1.json"),
+                StorageDrawers.rl("models/block/geometry/full_drawers_indbase_area_1.json"),
                     ModBlocks.getDrawersOfTypeAndSizeAndDepth(BlockDrawers.class, 1, false).toArray(BlockDrawers[]::new));
-            populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_icon_area_2.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_count_area_2.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_ind_area_2.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_indbase_area_2.json"),
+            populateGeometryData(StorageDrawers.rl("models/block/geometry/full_drawers_icon_area_2.json"),
+                StorageDrawers.rl("models/block/geometry/full_drawers_count_area_2.json"),
+                StorageDrawers.rl("models/block/geometry/full_drawers_ind_area_2.json"),
+                StorageDrawers.rl("models/block/geometry/full_drawers_indbase_area_2.json"),
                     ModBlocks.getDrawersOfTypeAndSizeAndDepth(BlockDrawers.class, 2, false).toArray(BlockDrawers[]::new));
-            populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_icon_area_4.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_count_area_4.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_ind_area_4.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/full_drawers_indbase_area_4.json"),
+            populateGeometryData(StorageDrawers.rl("models/block/geometry/full_drawers_icon_area_4.json"),
+                StorageDrawers.rl("models/block/geometry/full_drawers_count_area_4.json"),
+                StorageDrawers.rl("models/block/geometry/full_drawers_ind_area_4.json"),
+                StorageDrawers.rl("models/block/geometry/full_drawers_indbase_area_4.json"),
                     ModBlocks.getDrawersOfTypeAndSizeAndDepth(BlockDrawers.class, 4, false).toArray(BlockDrawers[]::new));
-            populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_icon_area_1.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_count_area_1.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_ind_area_1.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_indbase_area_1.json"),
+            populateGeometryData(StorageDrawers.rl("models/block/geometry/half_drawers_icon_area_1.json"),
+                StorageDrawers.rl("models/block/geometry/half_drawers_count_area_1.json"),
+                StorageDrawers.rl("models/block/geometry/half_drawers_ind_area_1.json"),
+                StorageDrawers.rl("models/block/geometry/half_drawers_indbase_area_1.json"),
                     ModBlocks.getDrawersOfTypeAndSizeAndDepth(BlockDrawers.class, 1, true).toArray(BlockDrawers[]::new));
-            populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_icon_area_2.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_count_area_2.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_ind_area_2.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_indbase_area_2.json"),
+            populateGeometryData(StorageDrawers.rl("models/block/geometry/half_drawers_icon_area_2.json"),
+                StorageDrawers.rl("models/block/geometry/half_drawers_count_area_2.json"),
+                StorageDrawers.rl("models/block/geometry/half_drawers_ind_area_2.json"),
+                StorageDrawers.rl("models/block/geometry/half_drawers_indbase_area_2.json"),
                     ModBlocks.getDrawersOfTypeAndSizeAndDepth(BlockDrawers.class, 2, true).toArray(BlockDrawers[]::new));
-            populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_icon_area_4.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_count_area_4.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_ind_area_4.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/half_drawers_indbase_area_4.json"),
+            populateGeometryData(StorageDrawers.rl("models/block/geometry/half_drawers_icon_area_4.json"),
+                StorageDrawers.rl("models/block/geometry/half_drawers_count_area_4.json"),
+                StorageDrawers.rl("models/block/geometry/half_drawers_ind_area_4.json"),
+                StorageDrawers.rl("models/block/geometry/half_drawers_indbase_area_4.json"),
                     ModBlocks.getDrawersOfTypeAndSizeAndDepth(BlockDrawers.class, 4, true).toArray(BlockDrawers[]::new));
-            populateGeometryData(new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/comp_drawers_icon_area_3.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/comp_drawers_count_area_3.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/comp_drawers_ind_area_3.json"),
-                new ResourceLocation(StorageDrawers.MOD_ID, "models/block/geometry/comp_drawers_indbase_area_3.json"),
+            populateGeometryData(StorageDrawers.rl("models/block/geometry/comp_drawers_icon_area_3.json"),
+                StorageDrawers.rl("models/block/geometry/comp_drawers_count_area_3.json"),
+                StorageDrawers.rl("models/block/geometry/comp_drawers_ind_area_3.json"),
+                StorageDrawers.rl("models/block/geometry/comp_drawers_indbase_area_3.json"),
                 ModBlocks.getBlocksOfType(BlockCompDrawers.class).toArray(BlockDrawers[]::new));
         }
 
@@ -208,26 +208,26 @@ public final class BasicDrawerModel
                 BlockModelRotation rot = BlockModelRotation.by(0, (int)dir.toYRot() + 180);
                 Function<Material, TextureAtlasSprite> texGet = ForgeModelBakery.defaultTextureGetter();
 
-                lockOverlaysFull.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/full_drawers_lock"), rot, texGet));
-                lockOverlaysHalf.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/half_drawers_lock"), rot, texGet));
-                voidOverlaysFull.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/full_drawers_void"), rot, texGet));
-                voidOverlaysHalf.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/half_drawers_void"), rot, texGet));
-                shroudOverlaysFull.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/full_drawers_shroud"), rot, texGet));
-                shroudOverlaysHalf.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/half_drawers_shroud"), rot, texGet));
-                indicator1Full.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/full_drawers_indicator_1"), rot, texGet));
-                indicator1Half.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/half_drawers_indicator_1"), rot, texGet));
-                indicator2Full.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/full_drawers_indicator_2"), rot, texGet));
-                indicator2Half.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/half_drawers_indicator_2"), rot, texGet));
-                indicator4Full.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/full_drawers_indicator_4"), rot, texGet));
-                indicator4Half.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/half_drawers_indicator_4"), rot, texGet));
-                indicatorComp.put(dir, event.getModelLoader().bake(new ResourceLocation(StorageDrawers.MOD_ID, "block/compdrawers_indicator"), rot, texGet));
+                lockOverlaysFull.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/full_drawers_lock"), rot, texGet));
+                lockOverlaysHalf.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/half_drawers_lock"), rot, texGet));
+                voidOverlaysFull.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/full_drawers_void"), rot, texGet));
+                voidOverlaysHalf.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/half_drawers_void"), rot, texGet));
+                shroudOverlaysFull.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/full_drawers_shroud"), rot, texGet));
+                shroudOverlaysHalf.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/half_drawers_shroud"), rot, texGet));
+                indicator1Full.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/full_drawers_indicator_1"), rot, texGet));
+                indicator1Half.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/half_drawers_indicator_1"), rot, texGet));
+                indicator2Full.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/full_drawers_indicator_2"), rot, texGet));
+                indicator2Half.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/half_drawers_indicator_2"), rot, texGet));
+                indicator4Full.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/full_drawers_indicator_4"), rot, texGet));
+                indicator4Half.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/half_drawers_indicator_4"), rot, texGet));
+                indicatorComp.put(dir, event.getModelLoader().bake(StorageDrawers.rl("block/compdrawers_indicator"), rot, texGet));
             }
 
             ModBlocks.getDrawers().forEach(blockDrawers -> replaceBlock(event, blockDrawers));
 
-            //event.getModelLoader().getBakedModel(new ResourceLocation(StorageDrawers.MOD_ID, "block/full_drawers_lock"), ModelRotation.X0_Y0, ModelLoader.defaultTextureGetter());
-            //event.getModelLoader().getBakedModel(new ResourceLocation(StorageDrawers.MOD_ID, "block/full_drawers_void"), ModelRotation.X0_Y0, ModelLoader.defaultTextureGetter());
-            //event.getModelLoader().getBakedModel(new ResourceLocation(StorageDrawers.MOD_ID, "block/full_drawers_shroud"), ModelRotation.X0_Y0, ModelLoader.defaultTextureGetter());
+            //event.getModelLoader().getBakedModel(StorageDrawers.rl("block/full_drawers_lock"), ModelRotation.X0_Y0, ModelLoader.defaultTextureGetter());
+            //event.getModelLoader().getBakedModel(StorageDrawers.rl("block/full_drawers_void"), ModelRotation.X0_Y0, ModelLoader.defaultTextureGetter());
+            //event.getModelLoader().getBakedModel(StorageDrawers.rl("block/full_drawers_shroud"), ModelRotation.X0_Y0, ModelLoader.defaultTextureGetter());
         }
 
         public static void replaceBlock(ModelBakeEvent event, BlockDrawers block) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
@@ -188,16 +188,20 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
         matrix.scale(1, -1, 1);
         matrix.scale(16, 16, 16);
 
-        BakedModel itemModel = itemRenderer.getModel(itemStack, null, null, 0);
-        boolean render3D = itemModel.isGui3d(); // itemModel.usesBlockLight();
+        try {
+            BakedModel itemModel = itemRenderer.getModel(itemStack, null, null, 0);
+            boolean render3D = itemModel.isGui3d(); // itemModel.usesBlockLight();
 
-        if (render3D)
-            Lighting.setupFor3DItems();
-        else
-            Lighting.setupForFlatItems();
+            if (render3D)
+                Lighting.setupFor3DItems();
+            else
+                Lighting.setupForFlatItems();
 
-        matrix.last().normal().load(Matrix3f.createScaleMatrix(1, 1, 1));
-        itemRenderer.render(itemStack, ItemTransforms.TransformType.GUI, false, matrix, buffer, combinedLight, combinedOverlay, itemModel);
+            matrix.last().normal().load(Matrix3f.createScaleMatrix(1, 1, 1));
+            itemRenderer.render(itemStack, ItemTransforms.TransformType.GUI, false, matrix, buffer, combinedLight, combinedOverlay, itemModel);
+        } catch (Exception e) {
+            // Shrug
+        }
 
         matrix.popPose();
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
@@ -55,21 +55,26 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
     public void render (@NotNull TileEntityDrawers tile, float partialTickTime, @NotNull PoseStack matrix, @NotNull MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
 
         Player player = Minecraft.getInstance().player;
-        if (player == null) return;
+        if (player == null)
+            return;
 
         Level world = tile.getLevel();
-        if (world == null) return;
+        if (world == null)
+            return;
 
         BlockState state = tile.getBlockState();
-        if (!(state.getBlock() instanceof BlockDrawers)) return;
+        if (!(state.getBlock() instanceof BlockDrawers))
+            return;
 
         Direction side = state.getValue(BlockDrawers.FACING);
-        if (playerBehindBlock(tile.getBlockPos(), side)) return;
+        if (playerBehindBlock(tile.getBlockPos(), side))
+            return;
 
         float distance = (float)Math.sqrt(tile.getBlockPos().distToCenterSqr(player.position()));
 
         double renderDistance = ClientConfig.RENDER.labelRenderDistance.get();
-        if (renderDistance > 0 && distance > renderDistance) return;
+        if (renderDistance > 0 && distance > renderDistance)
+            return;
 
         itemRenderer = Minecraft.getInstance().getItemRenderer();
 
@@ -91,7 +96,8 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
 
     private boolean playerBehindBlock(BlockPos blockPos, Direction facing) {
         Player player = Minecraft.getInstance().player;
-        if (player == null) return false;
+        if (player == null)
+            return false;
 
         BlockPos playerPos = player.blockPosition();
         return switch (facing) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
@@ -10,99 +10,79 @@ import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
 import com.jaquadro.minecraft.storagedrawers.util.CountFormatter;
 import com.mojang.blaze3d.platform.Lighting;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.math.Matrix3f;
 import com.mojang.math.Matrix4f;
-import net.minecraft.client.renderer.texture.TextureAtlas;
-import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.block.state.BlockState;
+import com.mojang.math.Quaternion;
+import com.mojang.math.Vector3f;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
-import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.entity.ItemRenderer;
-import net.minecraft.client.GraphicsStatus;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.core.Direction;
-import net.minecraft.world.phys.AABB;
+import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.BlockPos;
-import com.mojang.math.Matrix3f;
-import com.mojang.math.Quaternion;
-import com.mojang.math.Vector3f;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-
-import javax.annotation.Nonnull;
-import java.util.function.Consumer;
+import org.jetbrains.annotations.NotNull;
 
 @OnlyIn(Dist.CLIENT)
 public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntityDrawers>
 {
-    private boolean[] renderAsBlock = new boolean[4];
-    private ItemStack[] renderStacks = new ItemStack[4];
+    private final ItemStack[] renderStacks = new ItemStack[4];
 
-    private ItemRenderer renderItem;
+    private ItemRenderer itemRenderer;
 
-    private BlockEntityRendererProvider.Context context;
+    private final BlockEntityRendererProvider.Context context;
 
     public TileEntityDrawersRenderer (BlockEntityRendererProvider.Context context) {
         this.context = context;
     }
 
     @Override
-    public void render (TileEntityDrawers tile, float partialTickTime, PoseStack matrix, MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
-        if (tile == null)
-            return;
-
-        Level world = tile.getLevel();
-        if (world == null)
-            return;
-
-        BlockState state = tile.getBlockState();
-        if (state == null)
-            return;
-
-        if (!(state.getBlock() instanceof BlockDrawers))
-            return;
-
-        Direction side = state.getValue(BlockDrawers.FACING);
-        if (playerBehindBlock(tile.getBlockPos(), side))
-            return;
+    public void render (@NotNull TileEntityDrawers tile, float partialTickTime, @NotNull PoseStack matrix, @NotNull MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
 
         Player player = Minecraft.getInstance().player;
-        BlockPos blockPos = tile.getBlockPos().offset(.5, .5, .5);
-        float distance = (float)Math.sqrt(blockPos.distToCenterSqr(player.position()));
+        if (player == null) return;
+
+        Level world = tile.getLevel();
+        if (world == null) return;
+
+        BlockState state = tile.getBlockState();
+        if (!(state.getBlock() instanceof BlockDrawers)) return;
+
+        Direction side = state.getValue(BlockDrawers.FACING);
+        if (playerBehindBlock(tile.getBlockPos(), side)) return;
+
+        float distance = (float)Math.sqrt(tile.getBlockPos().distToCenterSqr(player.position()));
 
         double renderDistance = ClientConfig.RENDER.labelRenderDistance.get();
-        if (renderDistance > 0 && distance > renderDistance)
-            return;
+        if (renderDistance > 0 && distance > renderDistance) return;
 
-        renderItem = Minecraft.getInstance().getItemRenderer();
+        itemRenderer = Minecraft.getInstance().getItemRenderer();
 
         if (tile.upgrades().hasIlluminationUpgrade()) {
             int blockLight = Math.max(combinedLight % 65536, 208);
             combinedLight = (combinedLight & 0xFFFF0000) | blockLight;
         }
 
-        Minecraft mc = Minecraft.getInstance();
-        GraphicsStatus cache = mc.options.graphicsMode;
-        mc.options.graphicsMode = GraphicsStatus.FANCY;
-
         if (!tile.getDrawerAttributes().isConcealed())
             renderFastItemSet(tile, state, matrix, buffer, combinedLight, combinedOverlay, side, partialTickTime, distance);
 
         if (tile.getDrawerAttributes().hasFillLevel())
             renderIndicator((BlockDrawers)state.getBlock(), tile, matrix, buffer, state.getValue(BlockDrawers.FACING), combinedLight, combinedOverlay);
-
-        mc.options.graphicsMode = cache;
 
         matrix.popPose();
         Lighting.setupLevel(matrix.last().pose());
@@ -111,22 +91,16 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
 
     private boolean playerBehindBlock(BlockPos blockPos, Direction facing) {
         Player player = Minecraft.getInstance().player;
-        if (player == null)
-            return false;
+        if (player == null) return false;
 
         BlockPos playerPos = player.blockPosition();
-        switch (facing) {
-            case NORTH:
-                return playerPos.getZ() > blockPos.getZ();
-            case SOUTH:
-                return playerPos.getZ() < blockPos.getZ();
-            case WEST:
-                return playerPos.getX() > blockPos.getX();
-            case EAST:
-                return playerPos.getX() < blockPos.getX();
-            default:
-                return false;
-        }
+        return switch (facing) {
+            case NORTH -> playerPos.getZ() > blockPos.getZ();
+            case SOUTH -> playerPos.getZ() < blockPos.getZ();
+            case WEST -> playerPos.getX() > blockPos.getX();
+            case EAST -> playerPos.getX() < blockPos.getX();
+            default -> false;
+        };
     }
 
     private void renderFastItemSet (TileEntityDrawers tile, BlockState state, PoseStack matrix, MultiBufferSource buffer, int combinedLight, int combinedOverlay, Direction side, float partialTickTime, float distance) {
@@ -140,17 +114,12 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
 
             ItemStack itemStack = drawer.getStoredItemPrototype();
             renderStacks[i] = itemStack;
-            renderAsBlock[i] = isItemBlockType(itemStack);
         }
 
         for (int i = 0; i < drawerCount; i++) {
-            if (!renderStacks[i].isEmpty() && !renderAsBlock[i])
-                renderFastItem(renderStacks[i], tile, state, i, matrix, buffer, combinedLight, combinedOverlay, side, partialTickTime);
-        }
-
-        for (int i = 0; i < drawerCount; i++) {
-            if (!renderStacks[i].isEmpty() && renderAsBlock[i])
-                renderFastItem(renderStacks[i], tile, state, i, matrix, buffer, combinedLight, combinedOverlay, side, partialTickTime);
+            ItemStack itemStack = renderStacks[i];
+            if (!itemStack.isEmpty())
+                renderFastItem(itemStack, state, i, matrix, buffer, combinedLight, combinedOverlay, side);
         }
 
         if (tile.getDrawerAttributes().isShowingQuantity()) {
@@ -161,12 +130,10 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
 
             double renderDistance = ClientConfig.RENDER.quantityRenderDistance.get();
             if (renderDistance == 0 || distance < renderDistance) {
-                MultiBufferSource.BufferSource txtBuffer = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
                 for (int i = 0; i < drawerCount; i++) {
                     String format = CountFormatter.format(this.context.getFont(), tile.getGroup().getDrawer(i));
-                    renderText(format, state, i, matrix, txtBuffer, combinedLight, side, alpha);
+                    renderText(format, state, i, matrix, buffer, combinedLight, side, alpha);
                 }
-                txtBuffer.endBatch();
             }
         }
     }
@@ -196,7 +163,7 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
         matrix.popPose();
     }
 
-    private void renderFastItem (@Nonnull ItemStack itemStack, TileEntityDrawers tile, BlockState state, int slot, PoseStack matrix, MultiBufferSource buffer, int combinedLight, int combinedOverlay, Direction side, float partialTickTime) {
+    private void renderFastItem(@NotNull ItemStack itemStack, BlockState state, int slot, PoseStack matrix, MultiBufferSource buffer, int combinedLight, int combinedOverlay, Direction side) {
         BlockDrawers block = (BlockDrawers)state.getBlock();
         AABB labelGeometry = block.labelGeometry[slot];
 
@@ -211,44 +178,22 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
         alignRendering(matrix, side);
         moveRendering(matrix, scaleX, scaleY, moveX, moveY, moveZ);
 
-        //List<IRenderLabel> renderHandlers = StorageDrawers.renderRegistry.getRenderHandlers();
-        //for (IRenderLabel renderHandler : renderHandlers) {
-        //    renderHandler.render(tile, tile.getGroup(), slot, 0, partialTickTime);
-        //}
+        matrix.translate(0, 0, 100f);
+        matrix.scale(1, -1, 1);
+        matrix.scale(16, 16, 16);
 
-        Consumer<MultiBufferSource> finish = (MultiBufferSource buf) -> {
-            if (buf instanceof MultiBufferSource.BufferSource)
-                ((MultiBufferSource.BufferSource) buf).endBatch();
-        };
+        BakedModel itemModel = itemRenderer.getModel(itemStack, null, null, 0);
+        boolean render3D = itemModel.isGui3d(); // itemModel.usesBlockLight();
 
-        try {
-            matrix.translate(0, 0, 100f);
-            matrix.scale(1, -1, 1);
-            matrix.scale(16, 16, 16);
+        if (render3D)
+            Lighting.setupFor3DItems();
+        else
+            Lighting.setupForFlatItems();
 
-            //IRenderTypeBuffer.Impl buffer = Minecraft.getInstance().getRenderTypeBuffers().getBufferSource();
-            BakedModel itemModel = renderItem.getModel(itemStack, null, null, 0);
-            boolean render3D = itemModel.isGui3d(); // itemModel.usesBlockLight();
-            finish.accept(buffer);
-
-            if (render3D)
-                Lighting.setupFor3DItems();
-            else
-                Lighting.setupForFlatItems();
-
-            matrix.last().normal().load(Matrix3f.createScaleMatrix(1, 1, 1));
-            renderItem.render(itemStack, ItemTransforms.TransformType.GUI, false, matrix, buffer, combinedLight, combinedOverlay, itemModel);
-            finish.accept(buffer);
-        }
-        catch (Exception e) {
-            // Shrug
-        }
+        matrix.last().normal().load(Matrix3f.createScaleMatrix(1, 1, 1));
+        itemRenderer.render(itemStack, ItemTransforms.TransformType.GUI, false, matrix, buffer, combinedLight, combinedOverlay, itemModel);
 
         matrix.popPose();
-    }
-
-    private boolean isItemBlockType (@Nonnull ItemStack itemStack) {
-        return itemStack.getItem() instanceof BlockItem; // && renderItem.shouldRenderItemIn3D(itemStack);
     }
 
     private void alignRendering (PoseStack matrix, Direction side) {
@@ -280,10 +225,10 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
         return sideRotationY2D[side.ordinal()] * 90;
     }
 
-    public static final ResourceLocation TEXTURE_IND_1 = new ResourceLocation(StorageDrawers.MOD_ID, "blocks/indicator/indicator_1_on");
-    public static final ResourceLocation TEXTURE_IND_2 = new ResourceLocation(StorageDrawers.MOD_ID, "blocks/indicator/indicator_2_on");
-    public static final ResourceLocation TEXTURE_IND_4 = new ResourceLocation(StorageDrawers.MOD_ID, "blocks/indicator/indicator_4_on");
-    public static final ResourceLocation TEXTURE_IND_COMP = new ResourceLocation(StorageDrawers.MOD_ID, "blocks/indicator/indicator_comp_on");
+    public static final ResourceLocation TEXTURE_IND_1 = StorageDrawers.rl("blocks/indicator/indicator_1_on");
+    public static final ResourceLocation TEXTURE_IND_2 = StorageDrawers.rl("blocks/indicator/indicator_2_on");
+    public static final ResourceLocation TEXTURE_IND_4 = StorageDrawers.rl("blocks/indicator/indicator_4_on");
+    public static final ResourceLocation TEXTURE_IND_COMP = StorageDrawers.rl("blocks/indicator/indicator_comp_on");
 
     private void renderIndicator (BlockDrawers block, TileEntityDrawers tile, PoseStack matrixStack, MultiBufferSource buffer, Direction side, int combinedLight, int combinedOverlay) {
         int count = (tile instanceof TileEntityDrawersComp) ? 1 : block.getDrawerCount();

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlockEntities.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlockEntities.java
@@ -11,40 +11,44 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
-import java.util.function.Supplier;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public final class ModBlockEntities {
-    public static DeferredRegister<BlockEntityType<?>> BLOCK_ENTITY_REGISTER = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITIES, StorageDrawers.MOD_ID);
+    public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITY_REGISTER = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITIES, StorageDrawers.MOD_ID);
 
-    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_1 = BLOCK_ENTITY_REGISTER.register("standard_drawers_1",
-            drawerBlockEntitySupplier(TileEntityDrawersStandard.Slot1::new, BlockStandardDrawers.class, 1));
-    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_2 = BLOCK_ENTITY_REGISTER.register("standard_drawers_2",
-            drawerBlockEntitySupplier(TileEntityDrawersStandard.Slot2::new, BlockStandardDrawers.class, 2));
-    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_4 = BLOCK_ENTITY_REGISTER.register("standard_drawers_4",
-            drawerBlockEntitySupplier(TileEntityDrawersStandard.Slot4::new, BlockStandardDrawers.class, 4));
-    public static final RegistryObject<BlockEntityType<TileEntityDrawersComp>> FRACTIONAL_DRAWERS_3 = BLOCK_ENTITY_REGISTER.register("fractional_drawers_3",
-            drawerBlockEntitySupplier(TileEntityDrawersComp.Slot3::new, BlockCompDrawers.class, 3));
-    public static final RegistryObject<BlockEntityType<TileEntityController>> CONTROLLER = BLOCK_ENTITY_REGISTER.register("controller",
-            blockEntitySupplier(TileEntityController::new, BlockController.class));
-    public static final RegistryObject<BlockEntityType<TileEntitySlave>> CONTROLLER_SLAVE = BLOCK_ENTITY_REGISTER.register("controller_slave",
-            blockEntitySupplier(TileEntitySlave::new, BlockSlave.class));
+    private static final Set<RegistryObject<? extends BlockEntityType<? extends TileEntityDrawers>>> BLOCK_ENTITY_TYPES_WITH_RENDERERS = new HashSet<>();
+
+    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_1 = registerDrawerBlockEntityType("standard_drawers_1", TileEntityDrawersStandard.Slot1::new, BlockStandardDrawers.class, 1);
+    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_2 = registerDrawerBlockEntityType("standard_drawers_2", TileEntityDrawersStandard.Slot2::new, BlockStandardDrawers.class, 2);
+    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_4 = registerDrawerBlockEntityType("standard_drawers_4", TileEntityDrawersStandard.Slot4::new, BlockStandardDrawers.class, 4);
+    public static final RegistryObject<BlockEntityType<TileEntityDrawersComp>> FRACTIONAL_DRAWERS_3 = registerDrawerBlockEntityType("fractional_drawers_3", TileEntityDrawersComp.Slot3::new, BlockCompDrawers.class, 3);
+    public static final RegistryObject<BlockEntityType<TileEntityController>> CONTROLLER = registerBlockEntityType("controller", TileEntityController::new, BlockController.class);
+    public static final RegistryObject<BlockEntityType<TileEntitySlave>> CONTROLLER_SLAVE = registerBlockEntityType("controller_slave", TileEntitySlave::new, BlockSlave.class);
 
     private ModBlockEntities() {}
 
-    private static <BE extends TileEntityDrawers, B extends BlockDrawers> Supplier<BlockEntityType<BE>> drawerBlockEntitySupplier(BlockEntitySupplier<BE> blockEntitySupplier, Class<B> drawerBlockClass, int size) {
-        return constructSupplier(blockEntitySupplier, ModBlocks.getDrawersOfTypeAndSize(drawerBlockClass, size));
+    private static <BE extends TileEntityDrawers, B extends BlockDrawers> RegistryObject<BlockEntityType<BE>> registerDrawerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Class<B> drawerBlockClass, int size) {
+        RegistryObject<BlockEntityType<BE>> ro = registerBlockEntityType(name, blockEntitySupplier, ModBlocks.getDrawersOfTypeAndSize(drawerBlockClass, size));
+        BLOCK_ENTITY_TYPES_WITH_RENDERERS.add(ro);
+        return ro;
     }
 
-    private static <BE extends ChamTileEntity, B extends Block> Supplier<BlockEntityType<BE>> blockEntitySupplier(BlockEntitySupplier<BE> blockEntitySupplier, Class<B> blockClass) {
-        return constructSupplier(blockEntitySupplier, ModBlocks.getBlocksOfType(blockClass));
+    private static <BE extends ChamTileEntity, B extends Block> RegistryObject<BlockEntityType<BE>> registerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Class<B> blockClass) {
+        return registerBlockEntityType(name, blockEntitySupplier, ModBlocks.getBlocksOfType(blockClass));
     }
 
-    private static <BE extends ChamTileEntity, B extends Block> Supplier<BlockEntityType<BE>> constructSupplier(BlockEntitySupplier<BE> blockEntitySupplier, Stream<B> blockStream) {
-        return () -> BlockEntityType.Builder.of(blockEntitySupplier, blockStream.toArray(Block[]::new)).build(null);
+    private static <BE extends ChamTileEntity, B extends Block> RegistryObject<BlockEntityType<BE>> registerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Stream<B> blockStream) {
+        return BLOCK_ENTITY_REGISTER.register(name, () -> BlockEntityType.Builder.of(blockEntitySupplier, blockStream.toArray(Block[]::new)).build(null));
     }
 
     public static void register(IEventBus bus) {
         BLOCK_ENTITY_REGISTER.register(bus);
+    }
+
+    public static Set<RegistryObject<? extends BlockEntityType<? extends TileEntityDrawers>>> getBlockEntityTypesWithRenderers() {
+        return Collections.unmodifiableSet(BLOCK_ENTITY_TYPES_WITH_RENDERERS);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlocks.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlocks.java
@@ -121,7 +121,7 @@ public final class ModBlocks
         BLOCK_REGISTER.register(bus);
     }
 
-    public static <T extends Block> Stream<T> getBlocksOfType(Class<T> blockClass) {
+    public static <B extends Block> Stream<B> getBlocksOfType(Class<B> blockClass) {
         return BLOCK_REGISTER.getEntries()
                 .stream()
                 .filter(RegistryObject::isPresent)
@@ -134,12 +134,12 @@ public final class ModBlocks
         return getBlocksOfType(BlockDrawers.class);
     }
 
-    public static <T extends BlockDrawers> Stream<T> getDrawersOfTypeAndSize(Class<T> drawerClass, int size) {
+    public static <B extends BlockDrawers> Stream<B> getDrawersOfTypeAndSize(Class<B> drawerClass, int size) {
         return getBlocksOfType(drawerClass)
                 .filter(blockStandardDrawers -> blockStandardDrawers.getDrawerCount() == size);
     }
 
-    public static <T extends BlockDrawers> Stream<T> getDrawersOfTypeAndSizeAndDepth(Class<T> drawerClass, int size, boolean halfDepth) {
+    public static <B extends BlockDrawers> Stream<B> getDrawersOfTypeAndSizeAndDepth(Class<B> drawerClass, int size, boolean halfDepth) {
         return getDrawersOfTypeAndSize(drawerClass, size)
                 .filter(blockStandardDrawers -> blockStandardDrawers.isHalfDepth() == halfDepth);
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/TheOneProbe.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/TheOneProbe.java
@@ -25,7 +25,7 @@ public class TheOneProbe implements Function<ITheOneProbe, Void> {
     private static class DrawerProbeProvider implements IProbeInfoProvider {
         @Override
         public ResourceLocation getID() {
-            return new ResourceLocation(StorageDrawers.MOD_ID, "drawerprobe");
+            return StorageDrawers.rl("drawerprobe");
         }
 
         @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
@@ -8,7 +8,6 @@ import mcp.mobius.waila.api.*;
 import mcp.mobius.waila.api.config.IPluginConfig;
 import mcp.mobius.waila.api.ui.IElement;
 import mcp.mobius.waila.impl.ui.ItemStackElement;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 
 import javax.annotation.Nonnull;
@@ -27,9 +26,9 @@ public class Waila implements IWailaPlugin
     private void registerProvider(IRegistrar registrar) {
         WailaDrawer provider = new WailaDrawer();
 
-        registrar.addConfig(new ResourceLocation(StorageDrawers.MOD_ID, "display.content"), true);
-        registrar.addConfig(new ResourceLocation(StorageDrawers.MOD_ID, "display.stacklimit"), true);
-        registrar.addConfig(new ResourceLocation(StorageDrawers.MOD_ID, "display.status"), true);
+        registrar.addConfig(StorageDrawers.rl("display.content"), true);
+        registrar.addConfig(StorageDrawers.rl("display.stacklimit"), true);
+        registrar.addConfig(StorageDrawers.rl("display.status"), true);
         registrar.registerComponentProvider(provider, TooltipPosition.BODY, BlockDrawers.class);
     }
 
@@ -46,9 +45,9 @@ public class Waila implements IWailaPlugin
             TileEntityDrawers tile = (TileEntityDrawers) accessor.getBlockEntity();
 
             DrawerOverlay overlay = new DrawerOverlay();
-            overlay.showContent = config.get(new ResourceLocation(StorageDrawers.MOD_ID, "display.content"));
-            overlay.showStackLimit = config.get(new ResourceLocation(StorageDrawers.MOD_ID, "display.stacklimit"));
-            overlay.showStatus = config.get(new ResourceLocation(StorageDrawers.MOD_ID, "display.status"));
+            overlay.showContent = config.get(StorageDrawers.rl("display.content"));
+            overlay.showStackLimit = config.get(StorageDrawers.rl("display.stacklimit"));
+            overlay.showStatus = config.get(StorageDrawers.rl("display.status"));
 
             currenttip.addAll(overlay.getOverlay(tile));
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/DrawerScreen.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/DrawerScreen.java
@@ -17,10 +17,10 @@ import java.util.List;
 
 public class DrawerScreen extends AbstractContainerScreen<ContainerDrawers>
 {
-    private static final ResourceLocation guiTextures1 = new ResourceLocation(StorageDrawers.MOD_ID, "textures/gui/drawers_1.png");
-    private static final ResourceLocation guiTextures2 = new ResourceLocation(StorageDrawers.MOD_ID, "textures/gui/drawers_2.png");
-    private static final ResourceLocation guiTextures4 = new ResourceLocation(StorageDrawers.MOD_ID, "textures/gui/drawers_4.png");
-    private static final ResourceLocation guiTexturesComp = new ResourceLocation(StorageDrawers.MOD_ID, "textures/gui/drawers_comp.png");
+    private static final ResourceLocation guiTextures1 = StorageDrawers.rl("textures/gui/drawers_1.png");
+    private static final ResourceLocation guiTextures2 = StorageDrawers.rl("textures/gui/drawers_2.png");
+    private static final ResourceLocation guiTextures4 = StorageDrawers.rl("textures/gui/drawers_4.png");
+    private static final ResourceLocation guiTexturesComp = StorageDrawers.rl("textures/gui/drawers_comp.png");
 
     private static final int smDisabledX = 176;
     private static final int smDisabledY = 0;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/network/MessageHandler.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/network/MessageHandler.java
@@ -1,7 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.network;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.network.NetworkRegistry;
 import net.minecraftforge.network.simple.SimpleChannel;
 
@@ -9,7 +8,7 @@ public class MessageHandler
 {
     private static final String PROTOCOL_VERSION = "1";
     public static final SimpleChannel INSTANCE = NetworkRegistry.ChannelBuilder
-        .named(new ResourceLocation(StorageDrawers.MOD_ID, "main_channel"))
+        .named(StorageDrawers.rl("main_channel"))
         .networkProtocolVersion(() -> PROTOCOL_VERSION)
         .clientAcceptedVersions(PROTOCOL_VERSION::equals)
         .serverAcceptedVersions(PROTOCOL_VERSION::equals)


### PR DESCRIPTION
Currently, drawer item labels are rendered in a way which flushes the BufferSource every frame for every storage drawer which renders them. This takes a lot of CPU time (determined by [spark](https://www.curseforge.com/minecraft/mc-mods/spark) to be the most time-consuming operation in drawer rendering) and is unnecessary, since the buffer will be flushed anyway once it has collected all the vertex data from all BlockEntities.

This PR makes following changes to TileEntityDrawersRenderer:

- Remove manual buffer flushing, which was met with an immediate and significant FPS increase.
- Move text rendering to the main buffer instead of creating a separate one.
- Removed the graphics quality switch before rendering, as it didn't seem to affect label rendering in any meaningful way.

Additional changes in this PR:

- Replaced all invocations of `new ResourceLocation(String namespace, String path)` with a static method in `StorageDrawers`, making the code more compact.
- Tidied up `ModBlockEntities` and added bulk registration for BERs. Not sure what to do with an unchecked cast in `ClientEventBusSubscriber`, though.