### PR TITLE
Move ModContainers from ObjectHolders to DeferredRegisters

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
@@ -13,7 +13,6 @@ import com.jaquadro.minecraft.storagedrawers.network.MessageHandler;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.SimpleRecipeSerializer;
-import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -65,6 +64,7 @@ public class StorageDrawers
         ModBlocks.register(bus);
         ModItems.register(bus);
         ModBlockEntities.register(bus);
+        ModContainers.register(bus);
 
         bus.addListener(this::setup);
         bus.addListener(this::onModQueueEvent);
@@ -77,8 +77,6 @@ public class StorageDrawers
 
     private void setup (final FMLCommonSetupEvent event) {
         MessageHandler.init();
-
-        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> ModContainers.registerScreens());
 
         compRegistry = new CompTierRegistry();
         compRegistry.initialize();

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientEventBusSubscriber.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientEventBusSubscriber.java
@@ -20,7 +20,7 @@ public class ClientEventBusSubscriber {
     @SubscribeEvent
     public static void clientSetup(FMLClientSetupEvent event) {
         ModBlocks.getDrawers().forEach(blockDrawers -> ItemBlockRenderTypes.setRenderLayer(blockDrawers, RenderType.cutoutMipped()));
-        event.enqueueWork(()-> {
+        event.enqueueWork(() -> {
             /*
             I'd like to do this registration in bulk as well, but I'm hesitant to put
             client-only code in common classes like ModContainers (memorizing screen types).

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientEventBusSubscriber.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientEventBusSubscriber.java
@@ -4,6 +4,9 @@ import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.client.renderer.TileEntityDrawersRenderer;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlockEntities;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
+import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
+import com.jaquadro.minecraft.storagedrawers.inventory.DrawerScreen;
+import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraftforge.api.distmarker.Dist;
@@ -17,6 +20,17 @@ public class ClientEventBusSubscriber {
     @SubscribeEvent
     public static void clientSetup(FMLClientSetupEvent event) {
         ModBlocks.getDrawers().forEach(blockDrawers -> ItemBlockRenderTypes.setRenderLayer(blockDrawers, RenderType.cutoutMipped()));
+        event.enqueueWork(()-> {
+            /*
+            I'd like to do this registration in bulk as well, but I'm hesitant to put
+            client-only code in common classes like ModContainers (memorizing screen types).
+            BERs at least all have the same renderer.
+            */
+            MenuScreens.register(ModContainers.DRAWER_CONTAINER_1.get(), DrawerScreen.Slot1::new);
+            MenuScreens.register(ModContainers.DRAWER_CONTAINER_2.get(), DrawerScreen.Slot2::new);
+            MenuScreens.register(ModContainers.DRAWER_CONTAINER_4.get(), DrawerScreen.Slot4::new);
+            MenuScreens.register(ModContainers.DRAWER_CONTAINER_COMP.get(), DrawerScreen.Compacting::new);
+        });
     }
 
     @SubscribeEvent

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModContainers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModContainers.java
@@ -2,38 +2,28 @@ package com.jaquadro.minecraft.storagedrawers.core;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.inventory.*;
-import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraftforge.common.extensions.IForgeMenuType;
-import net.minecraftforge.event.RegistryEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.registries.ObjectHolder;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.network.IContainerFactory;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
 
-@ObjectHolder(StorageDrawers.MOD_ID)
 public class ModContainers
 {
-    public static final MenuType<ContainerDrawers1> DRAWER_CONTAINER_1 = null;
-    public static final MenuType<ContainerDrawers2> DRAWER_CONTAINER_2 = null;
-    public static final MenuType<ContainerDrawers4> DRAWER_CONTAINER_4 = null;
-    public static final MenuType<ContainerDrawersComp> DRAWER_CONTAINER_COMP = null;
+    public static final DeferredRegister<MenuType<?>> CONTAINERS_REGISTER = DeferredRegister.create(ForgeRegistries.CONTAINERS, StorageDrawers.MOD_ID);
 
-    @Mod.EventBusSubscriber(modid = StorageDrawers.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
-    public static class Registration {
+    public static final RegistryObject<MenuType<ContainerDrawers1>> DRAWER_CONTAINER_1 = registerContainer("drawer_container_1", ContainerDrawers1::new);
+    public static final RegistryObject<MenuType<ContainerDrawers2>> DRAWER_CONTAINER_2 = registerContainer("drawer_container_2", ContainerDrawers2::new);
+    public static final RegistryObject<MenuType<ContainerDrawers4>> DRAWER_CONTAINER_4 = registerContainer("drawer_container_4", ContainerDrawers4::new);
+    public static final RegistryObject<MenuType<ContainerDrawersComp>> DRAWER_CONTAINER_COMP = registerContainer("drawer_container_comp", ContainerDrawersComp::new);
 
-        @SubscribeEvent
-        public static void registerContainers (RegistryEvent.Register<MenuType<?>> event) {
-            event.getRegistry().register(IForgeMenuType.create(ContainerDrawers1::new).setRegistryName("drawer_container_1"));
-            event.getRegistry().register(IForgeMenuType.create(ContainerDrawers2::new).setRegistryName("drawer_container_2"));
-            event.getRegistry().register(IForgeMenuType.create(ContainerDrawers4::new).setRegistryName("drawer_container_4"));
-            event.getRegistry().register(IForgeMenuType.create(ContainerDrawersComp::new).setRegistryName("drawer_container_comp"));
-        }
+    private static <C extends ContainerDrawers> RegistryObject<MenuType<C>> registerContainer(String name, IContainerFactory<C> containerFactory) {
+        return CONTAINERS_REGISTER.register(name, () -> IForgeMenuType.create(containerFactory));
     }
 
-    public static void registerScreens () {
-        MenuScreens.register(DRAWER_CONTAINER_1, DrawerScreen.Slot1::new);
-        MenuScreens.register(DRAWER_CONTAINER_2, DrawerScreen.Slot2::new);
-        MenuScreens.register(DRAWER_CONTAINER_4, DrawerScreen.Slot4::new);
-        MenuScreens.register(DRAWER_CONTAINER_COMP, DrawerScreen.Compacting::new);
+    public static void register(IEventBus bus) {
+        CONTAINERS_REGISTER.register(bus);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers1.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers1.java
@@ -12,11 +12,11 @@ public class ContainerDrawers1 extends ContainerDrawers
     };
 
     public ContainerDrawers1 (int windowId, Inventory playerInv, FriendlyByteBuf data) {
-        super(ModContainers.DRAWER_CONTAINER_1, windowId, playerInv, data);
+        super(ModContainers.DRAWER_CONTAINER_1.get(), windowId, playerInv, data);
     }
 
     public ContainerDrawers1 (int windowId, Inventory playerInventory, TileEntityDrawers tileEntity) {
-        super(ModContainers.DRAWER_CONTAINER_1, windowId, playerInventory, tileEntity);
+        super(ModContainers.DRAWER_CONTAINER_1.get(), windowId, playerInventory, tileEntity);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers2.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers2.java
@@ -12,11 +12,11 @@ public class ContainerDrawers2 extends ContainerDrawers
     };
 
     public ContainerDrawers2 (int windowId, Inventory playerInv, FriendlyByteBuf data) {
-        super(ModContainers.DRAWER_CONTAINER_2, windowId, playerInv, data);
+        super(ModContainers.DRAWER_CONTAINER_2.get(), windowId, playerInv, data);
     }
 
     public ContainerDrawers2 (int windowId, Inventory playerInventory, TileEntityDrawers tileEntity) {
-        super(ModContainers.DRAWER_CONTAINER_2, windowId, playerInventory, tileEntity);
+        super(ModContainers.DRAWER_CONTAINER_2.get(), windowId, playerInventory, tileEntity);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers4.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers4.java
@@ -12,11 +12,11 @@ public class ContainerDrawers4 extends ContainerDrawers
     };
 
     public ContainerDrawers4 (int windowId, Inventory playerInv, FriendlyByteBuf data) {
-        super(ModContainers.DRAWER_CONTAINER_4, windowId, playerInv, data);
+        super(ModContainers.DRAWER_CONTAINER_4.get(), windowId, playerInv, data);
     }
 
     public ContainerDrawers4 (int windowId, Inventory playerInventory, TileEntityDrawers tileEntity) {
-        super(ModContainers.DRAWER_CONTAINER_4, windowId, playerInventory, tileEntity);
+        super(ModContainers.DRAWER_CONTAINER_4.get(), windowId, playerInventory, tileEntity);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawersComp.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawersComp.java
@@ -12,11 +12,11 @@ public class ContainerDrawersComp extends ContainerDrawers
     };
 
     public ContainerDrawersComp (int windowId, Inventory playerInventory, FriendlyByteBuf packet) {
-        super(ModContainers.DRAWER_CONTAINER_COMP, windowId, playerInventory, packet);
+        super(ModContainers.DRAWER_CONTAINER_COMP.get(), windowId, playerInventory, packet);
     }
 
     public ContainerDrawersComp (int windowId, Inventory playerInventory, TileEntityDrawers tile) {
-        super(ModContainers.DRAWER_CONTAINER_COMP, windowId, playerInventory, tile);
+        super(ModContainers.DRAWER_CONTAINER_COMP.get(), windowId, playerInventory, tile);
     }
 
     @Override


### PR DESCRIPTION
Like https://github.com/jaquadro/StorageDrawers/pull/1013, but for ModContainers, which I unfortunately glossed over during that PR.

As a side effect, gets rid of the ugly DistExecutor call in the main class.