### PR TITLE
Improve drawer interaction logic and a bunch of refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
+        classpath 'org.spongepowered:mixingradle:0.7.+'
     }
 }
 
@@ -16,6 +17,7 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'idea'
 apply plugin: 'maven-publish'
+apply plugin: 'org.spongepowered.mixin'
 
 version = "${minecraft_version}-${mod_version}"
 group= "com.jaquadro.minecraft.storagedrawers" // http://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,7 @@ dependencies {
 
     implementation fg.deobf("curse.maven:the-one-probe-245211:${top_id}")
     implementation fg.deobf("curse.maven:jade-324717:${jade_id}")
+//    implementation fg.deobf("curse.maven:spark-361579:3670050")
 
     //deobfCompile "MineTweaker3:MineTweaker3-API:${mt_version}"
     //deobfCompile "org.ow2.asm:asm-debug-all:5.0.3"

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
@@ -18,7 +18,6 @@ import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -39,9 +38,6 @@ public class StorageDrawers
     public static final String MOD_ID = "storagedrawers";
     public static final Api api = new Api();
     public static Logger log = LogManager.getLogger();
-
-    public static CommonProxy proxy;
-
     //public static ConfigManager config;
     public static CompTierRegistry compRegistry;
     //public static OreDictRegistry oreDictRegistry;
@@ -54,8 +50,6 @@ public class StorageDrawers
     public static final RegistryObject<RecipeSerializer<AddUpgradeRecipe>> UPGRADE_RECIPE_SERIALIZER = RECIPES.register("add_upgrade", () -> new SimpleRecipeSerializer<>(AddUpgradeRecipe::new));
 
     public StorageDrawers () {
-        proxy = DistExecutor.runForDist(() -> ClientProxy::new, () -> CommonProxy::new);
-
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, CommonConfig.spec);
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ClientConfig.spec);
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/IStorageDrawersApi.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/IStorageDrawersApi.java
@@ -1,8 +1,5 @@
 package com.jaquadro.minecraft.storagedrawers.api;
 
-import com.jaquadro.minecraft.storagedrawers.api.registry.IRenderRegistry;
-import com.jaquadro.minecraft.storagedrawers.api.registry.IWailaRegistry;
-
 public interface IStorageDrawersApi
 {
     //IRenderRegistry renderRegistry ();

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/StorageDrawersApi.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/StorageDrawersApi.java
@@ -17,7 +17,7 @@ public class StorageDrawersApi
     public static IStorageDrawersApi instance () {
         if (instance == null) {
             try {
-                Class classApi = Class.forName( "com.jaquadro.minecraft.storagedrawers.core.Api" );
+                Class<?> classApi = Class.forName( "com.jaquadro.minecraft.storagedrawers.core.Api" );
                 instance = (IStorageDrawersApi) classApi.getField("instance").get(null);
             }
             catch (Throwable t) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/capabilities/IItemRepository.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/capabilities/IItemRepository.java
@@ -1,9 +1,9 @@
 package com.jaquadro.minecraft.storagedrawers.api.capabilities;
 
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.function.Predicate;
 
 /**
@@ -23,7 +23,7 @@ public interface IItemRepository
 
      * @return A list of zero or more items in the inventory.
      */
-    @Nonnull
+    @NotNull
     NonNullList<ItemRecord> getAllItems ();
 
     /**
@@ -35,11 +35,11 @@ public interface IItemRepository
      * @return The remaining ItemStack that was not inserted.  If the entire stack was accepted, returns
      * ItemStack.EMPTY instead.
      */
-    @Nonnull
-    ItemStack insertItem (@Nonnull ItemStack stack, boolean simulate, Predicate<ItemStack> predicate);
+    @NotNull
+    ItemStack insertItem (@NotNull ItemStack stack, boolean simulate, Predicate<ItemStack> predicate);
 
-    @Nonnull
-    default ItemStack insertItem (@Nonnull ItemStack stack, boolean simulate) {
+    @NotNull
+    default ItemStack insertItem (@NotNull ItemStack stack, boolean simulate) {
         return insertItem(stack, simulate, null);
     }
 
@@ -54,11 +54,11 @@ public interface IItemRepository
      * @param predicate See interface notes about predicates.  Passing null specifies default matching.
      * @return ItemStack extracted from the inventory, or ItemStack.EMPTY if nothing could be extracted.
      */
-    @Nonnull
-    ItemStack extractItem (@Nonnull ItemStack stack, int amount, boolean simulate, Predicate<ItemStack> predicate);
+    @NotNull
+    ItemStack extractItem (@NotNull ItemStack stack, int amount, boolean simulate, Predicate<ItemStack> predicate);
 
-    @Nonnull
-    default ItemStack extractItem (@Nonnull ItemStack stack, int amount, boolean simulate) {
+    @NotNull
+    default ItemStack extractItem (@NotNull ItemStack stack, int amount, boolean simulate) {
         return extractItem(stack, amount, simulate, null);
     }
 
@@ -69,12 +69,12 @@ public interface IItemRepository
      * @param predicate See interface notes about predicates.  Passing null specifies default matching.
      * @return The number of stored matching items.  A value of Integer.MAX_VALUE may indicate an infinite item source.
      */
-    default int getStoredItemCount (@Nonnull ItemStack stack, Predicate<ItemStack> predicate) {
+    default int getStoredItemCount (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
         ItemStack amount = extractItem(stack, Integer.MAX_VALUE, true, predicate);
         return amount.getCount();
     }
 
-    default int getStoredItemCount (@Nonnull ItemStack stack) {
+    default int getStoredItemCount (@NotNull ItemStack stack) {
         return getStoredItemCount(stack, null);
     }
 
@@ -86,14 +86,14 @@ public interface IItemRepository
      * @param predicate See interface notes about predicates.  Passing null specifies default matching.
      * @return The available remaining space for matching items.
      */
-    default int getRemainingItemCapacity (@Nonnull ItemStack stack, Predicate<ItemStack> predicate) {
+    default int getRemainingItemCapacity (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
         stack = stack.copy();
         stack.setCount(Integer.MAX_VALUE);
         ItemStack remainder = insertItem(stack, true, predicate);
         return Integer.MAX_VALUE - remainder.getCount();
     }
 
-    default int getRemainingItemCapacity (@Nonnull ItemStack stack) {
+    default int getRemainingItemCapacity (@NotNull ItemStack stack) {
         return getRemainingItemCapacity(stack, null);
     }
 
@@ -105,14 +105,14 @@ public interface IItemRepository
      * @param predicate See interface notes about predicates.  Passing null specifies default matching.
      * @return The total capacity for matching items.
      */
-    default int getItemCapacity (@Nonnull ItemStack stack, Predicate<ItemStack> predicate) {
-        long capacity = getStoredItemCount(stack, predicate) + getRemainingItemCapacity(stack, predicate);
+    default int getItemCapacity (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
+        long capacity = (long) getStoredItemCount(stack, predicate) + getRemainingItemCapacity(stack, predicate);
         if (capacity > Integer.MAX_VALUE)
             return Integer.MAX_VALUE;
         return (int)capacity;
     }
 
-    default int getItemCapacity (@Nonnull ItemStack stack) {
+    default int getItemCapacity (@NotNull ItemStack stack) {
         return getItemCapacity(stack, null);
     }
 
@@ -124,11 +124,11 @@ public interface IItemRepository
      */
     class ItemRecord
     {
-        @Nonnull
+        @NotNull
         public final ItemStack itemPrototype;
         public final int count;
 
-        public ItemRecord (@Nonnull ItemStack itemPrototype, int count) {
+        public ItemRecord (@NotNull ItemStack itemPrototype, int count) {
             this.itemPrototype = itemPrototype;
             this.count = count;
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/render/IRenderLabel.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/render/IRenderLabel.java
@@ -5,5 +5,5 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 
 public interface IRenderLabel
 {
-    void render (BlockEntity tileEntity, IDrawerGroup drawerGroup, int slot, float brightness, float partialTickTime);
+    void render (BlockEntity blockEntity, IDrawerGroup drawerGroup, int slot, float brightness, float partialTickTime);
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/Drawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/Drawers.java
@@ -1,8 +1,8 @@
 package com.jaquadro.minecraft.storagedrawers.api.storage;
 
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.function.Predicate;
 
 public class Drawers
@@ -12,15 +12,15 @@ public class Drawers
 
     private static class DisabledDrawer implements IDrawer
     {
-        @Nonnull
+        @NotNull
         @Override
         public ItemStack getStoredItemPrototype () {
             return ItemStack.EMPTY;
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public IDrawer setStoredItem (@Nonnull ItemStack itemPrototype) {
+        public IDrawer setStoredItem (@NotNull ItemStack itemPrototype) {
             return this;
         }
 
@@ -35,7 +35,7 @@ public class Drawers
         }
 
         @Override
-        public int getMaxCapacity (@Nonnull ItemStack itemPrototype) {
+        public int getMaxCapacity (@NotNull ItemStack itemPrototype) {
             return 0;
         }
 
@@ -45,12 +45,12 @@ public class Drawers
         }
 
         @Override
-        public boolean canItemBeStored (@Nonnull ItemStack itemPrototype, Predicate<ItemStack> matchPredicate) {
+        public boolean canItemBeStored (@NotNull ItemStack itemPrototype, Predicate<ItemStack> matchPredicate) {
             return false;
         }
 
         @Override
-        public boolean canItemBeExtracted (@Nonnull ItemStack itemPrototype, Predicate<ItemStack> matchPredicate) {
+        public boolean canItemBeExtracted (@NotNull ItemStack itemPrototype, Predicate<ItemStack> matchPredicate) {
             return false;
         }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/EnumBasicDrawer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/EnumBasicDrawer.java
@@ -1,8 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.api.storage;
 
 import net.minecraft.util.StringRepresentable;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public enum EnumBasicDrawer implements IDrawerGeometry, StringRepresentable
 {
@@ -58,7 +57,7 @@ public enum EnumBasicDrawer implements IDrawerGeometry, StringRepresentable
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public String getSerializedName () {
         return name;
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
@@ -1,8 +1,8 @@
 package com.jaquadro.minecraft.storagedrawers.api.storage;
 
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.function.Predicate;
 
 public interface IDrawer
@@ -13,7 +13,7 @@ public interface IDrawer
      *
      * To emphasize, DO NOT MODIFY THE ITEM STACK RETURNED BY THIS METHOD.
      */
-    @Nonnull
+    @NotNull
     ItemStack getStoredItemPrototype ();
 
     /**
@@ -22,8 +22,8 @@ public interface IDrawer
      * @param itemPrototype An ItemStack representing the type, metadata, and tags of the item to store.
      * @return The IDrawer actually set with the prototype.  Some drawer groups can redirect a set operation to another member.
      */
-    @Nonnull
-    IDrawer setStoredItem (@Nonnull ItemStack itemPrototype);
+    @NotNull
+    IDrawer setStoredItem (@NotNull ItemStack itemPrototype);
 
     /**
      * Sets the type of the stored item and initializes it to the given amount.  Any existing item will be replaced.
@@ -32,8 +32,8 @@ public interface IDrawer
      * @param amount The amount of items stored in this drawer.
      * @return The IDrawer actually set with the prototype.  Some drawer groups can redirect a set operation to another member.
      */
-    @Nonnull
-    default IDrawer setStoredItem (@Nonnull ItemStack itemPrototype, int amount) {
+    @NotNull
+    default IDrawer setStoredItem (@NotNull ItemStack itemPrototype, int amount) {
         IDrawer drawer = setStoredItem(itemPrototype);
         drawer.setStoredItemCount(amount);
         return drawer;
@@ -87,7 +87,7 @@ public interface IDrawer
      *
      * @param itemPrototype The item type to query.  Pass the empty stack to get the max capacity for an empty slot.
      */
-    int getMaxCapacity (@Nonnull ItemStack itemPrototype);
+    int getMaxCapacity (@NotNull ItemStack itemPrototype);
 
     /**
      * Gets the maximum number of items that would be accepted for storage by this drawer.
@@ -95,7 +95,7 @@ public interface IDrawer
      * Because a drawer may be able to handle items in excess of its full capacity, this value may be larger than
      * the result of getMaxCapacity().
      */
-    default int getAcceptingMaxCapacity (@Nonnull ItemStack itemPrototype) {
+    default int getAcceptingMaxCapacity (@NotNull ItemStack itemPrototype) {
         return getMaxCapacity(itemPrototype);
     }
 
@@ -118,7 +118,7 @@ public interface IDrawer
      * Gets the max stack size of the item type stored in this drawer.
      */
     default int getStoredItemStackSize () {
-        @Nonnull ItemStack protoStack = getStoredItemPrototype();
+        @NotNull ItemStack protoStack = getStoredItemPrototype();
         if (protoStack.isEmpty())
             return 0;
 
@@ -135,9 +135,9 @@ public interface IDrawer
      * @param matchPredicate    A custom predicate for testing the stored ItemStack for equivalence.
      * @return
      */
-    boolean canItemBeStored (@Nonnull ItemStack itemPrototype, Predicate<ItemStack> matchPredicate);
+    boolean canItemBeStored (@NotNull ItemStack itemPrototype, Predicate<ItemStack> matchPredicate);
 
-    default boolean canItemBeStored (@Nonnull ItemStack itemPrototype) {
+    default boolean canItemBeStored (@NotNull ItemStack itemPrototype) {
         return canItemBeStored(itemPrototype, null);
     }
 
@@ -151,9 +151,9 @@ public interface IDrawer
      * @param itemPrototype     An ItemStack representing the type, metadata, and tags of an item.
      * @param matchPredicate    A custom predicate for testing the stored ItemStack for equivalence.
      */
-    boolean canItemBeExtracted (@Nonnull ItemStack itemPrototype, Predicate<ItemStack> matchPredicate);
+    boolean canItemBeExtracted (@NotNull ItemStack itemPrototype, Predicate<ItemStack> matchPredicate);
 
-    default boolean canItemBeExtracted (@Nonnull ItemStack itemPrototype) {
+    default boolean canItemBeExtracted (@NotNull ItemStack itemPrototype) {
         return canItemBeExtracted(itemPrototype, null);
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawerGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawerGroup.java
@@ -4,9 +4,8 @@ import net.minecraft.core.Direction;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface IDrawerGroup extends ICapabilityProvider
 {
@@ -18,13 +17,12 @@ public interface IDrawerGroup extends ICapabilityProvider
     /**
      * Gets the drawer at the given slot within this group.
      */
-    @Nonnull
+    @NotNull
     IDrawer getDrawer (int slot);
 
     /**
      * Gets the list of available drawer slots in priority order.
      */
-    @Nonnull
     int[] getAccessibleDrawerSlots ();
 
     /**
@@ -34,9 +32,9 @@ public interface IDrawerGroup extends ICapabilityProvider
         return true;
     };
 
-    @Nonnull
     @Override
-    default <T> LazyOptional<T> getCapability (@Nonnull final Capability<T> cap, final @Nullable Direction side) {
+    @NotNull
+    default <T> LazyOptional<T> getCapability (@NotNull final Capability<T> cap, final @Nullable Direction side) {
         return LazyOptional.empty();
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockCompDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockCompDrawers.java
@@ -2,8 +2,8 @@ package com.jaquadro.minecraft.storagedrawers.block;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
 import com.jaquadro.minecraft.storagedrawers.api.storage.INetworked;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawersComp;
 import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -56,9 +56,9 @@ public class BlockCompDrawers extends BlockDrawers implements INetworked
     public void setPlacedBy (@NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState state, LivingEntity entity, @NotNull ItemStack stack) {
         super.setPlacedBy(world, pos, state, entity, stack);
 
-        TileEntityDrawersComp tileEntityDrawersComp = WorldUtils.getBlockEntity(world, pos, TileEntityDrawersComp.class);
-        if (tileEntityDrawersComp != null) {
-            IDrawerGroup group = tileEntityDrawersComp.getGroup();
+        BlockEntityDrawersComp blockEntity = WorldUtils.getBlockEntity(world, pos, BlockEntityDrawersComp.class);
+        if (blockEntity != null) {
+            IDrawerGroup group = blockEntity.getGroup();
             for (int i = group.getDrawerCount() - 1; i >= 0; i--) {
                 if (!group.getDrawer(i).isEmpty()) {
                     world.setBlock(pos, state.setValue(SLOTS, EnumCompDrawer.byOpenSlots(i + 1)), 3);
@@ -69,7 +69,7 @@ public class BlockCompDrawers extends BlockDrawers implements INetworked
     }
 
     @Override
-    public TileEntityDrawers newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
-        return new TileEntityDrawersComp.Slot3(pos, state);
+    public BlockEntityDrawers newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
+        return new BlockEntityDrawersComp.Slot3(pos, state);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockCompDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockCompDrawers.java
@@ -41,7 +41,7 @@ public class BlockCompDrawers extends BlockDrawers implements INetworked
     @Override
     protected int getDrawerSlot (Direction correctSide, @NotNull Vec3 normalizedHit) {
         if (!hitAny(correctSide, normalizedHit))
-            return -1;
+            return super.getDrawerSlot(correctSide, normalizedHit);
 
         if (hitTop(normalizedHit))
             return 0;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockCompDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockCompDrawers.java
@@ -2,8 +2,8 @@ package com.jaquadro.minecraft.storagedrawers.block;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
 import com.jaquadro.minecraft.storagedrawers.api.storage.INetworked;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawersComp;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp;
 import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -56,9 +56,9 @@ public class BlockCompDrawers extends BlockDrawers implements INetworked
     public void setPlacedBy (@NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState state, LivingEntity entity, @NotNull ItemStack stack) {
         super.setPlacedBy(world, pos, state, entity, stack);
 
-        BlockEntityDrawersComp blockEntity = WorldUtils.getBlockEntity(world, pos, BlockEntityDrawersComp.class);
-        if (blockEntity != null) {
-            IDrawerGroup group = blockEntity.getGroup();
+        TileEntityDrawersComp tileEntityDrawersComp = WorldUtils.getBlockEntity(world, pos, TileEntityDrawersComp.class);
+        if (tileEntityDrawersComp != null) {
+            IDrawerGroup group = tileEntityDrawersComp.getGroup();
             for (int i = group.getDrawerCount() - 1; i >= 0; i--) {
                 if (!group.getDrawer(i).isEmpty()) {
                     world.setBlock(pos, state.setValue(SLOTS, EnumCompDrawer.byOpenSlots(i + 1)), 3);
@@ -69,7 +69,7 @@ public class BlockCompDrawers extends BlockDrawers implements INetworked
     }
 
     @Override
-    public BlockEntityDrawers newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
-        return new BlockEntityDrawersComp.Slot3(pos, state);
+    public TileEntityDrawers newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
+        return new TileEntityDrawersComp.Slot3(pos, state);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockCompDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockCompDrawers.java
@@ -1,30 +1,26 @@
 package com.jaquadro.minecraft.storagedrawers.block;
 
-import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
 import com.jaquadro.minecraft.storagedrawers.api.storage.INetworked;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawersComp;
+import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.state.properties.EnumProperty;
-import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.core.Direction;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockCompDrawers extends BlockDrawers implements INetworked
 {
     public static final EnumProperty<EnumCompDrawer> SLOTS = EnumProperty.create("slots", EnumCompDrawer.class);
-
-    //@SideOnly(Side.CLIENT)
-    //private StatusModelData statusInfo;
 
     public BlockCompDrawers (int storageUnits, BlockBehaviour.Properties properties) {
         super(3, false, storageUnits, properties);
@@ -42,36 +38,27 @@ public class BlockCompDrawers extends BlockDrawers implements INetworked
         builder.add(SLOTS);
     }
 
-    /*@Override
-    @SideOnly(Side.CLIENT)
-    public void initDynamic () {
-        ResourceLocation location = new ResourceLocation(StorageDrawers.MOD_ID + ":models/dynamic/compDrawers.json");
-        statusInfo = new StatusModelData(3, location);
-    }*/
-
-    /*@Override
-    public StatusModelData getStatusInfo (IBlockState state) {
-        return statusInfo;
-    }*/
-
     @Override
-    protected int getDrawerSlot (Direction side, Vec3 hit) {
-        if (hitTop(hit.y))
+    protected int getDrawerSlot (Direction correctSide, @NotNull Vec3 normalizedHit) {
+        if (!hitAny(correctSide, normalizedHit))
+            return -1;
+
+        if (hitTop(normalizedHit))
             return 0;
 
-        if (hitLeft(side, hit.x, hit.z))
+        if (hitLeft(correctSide, normalizedHit))
             return 1;
         else
             return 2;
     }
 
     @Override
-    public void setPlacedBy (Level world, BlockPos pos, BlockState state, LivingEntity entity, ItemStack stack) {
+    public void setPlacedBy (@NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState state, LivingEntity entity, @NotNull ItemStack stack) {
         super.setPlacedBy(world, pos, state, entity, stack);
 
-        TileEntityDrawers tile = getTileEntity(world, pos);
-        if (tile != null) {
-            IDrawerGroup group = tile.getGroup();
+        BlockEntityDrawersComp blockEntity = WorldUtils.getBlockEntity(world, pos, BlockEntityDrawersComp.class);
+        if (blockEntity != null) {
+            IDrawerGroup group = blockEntity.getGroup();
             for (int i = group.getDrawerCount() - 1; i >= 0; i--) {
                 if (!group.getDrawer(i).isEmpty()) {
                     world.setBlock(pos, state.setValue(SLOTS, EnumCompDrawer.byOpenSlots(i + 1)), 3);
@@ -81,23 +68,8 @@ public class BlockCompDrawers extends BlockDrawers implements INetworked
         }
     }
 
-    /*@Override
-    public IBlockState getStateForPlacement (World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer, EnumHand hand) {
-        return getDefaultState();
-    }*/
-
-    /*@Override
-    public BlockType retrimType () {
-        return null;
-    }*/
-
     @Override
-    public TileEntityDrawers newBlockEntity (BlockPos pos, BlockState state) {
-        return new TileEntityDrawersComp.Slot3(pos, state);
+    public BlockEntityDrawers newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
+        return new BlockEntityDrawersComp.Slot3(pos, state);
     }
-
-    /*@Override
-    protected BlockStateContainer createBlockState () {
-        return new ExtendedBlockState(this, new IProperty[] { SLOTS, FACING }, new IUnlistedProperty[] { STATE_MODEL });
-    }*/
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockController.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockController.java
@@ -2,7 +2,7 @@ package com.jaquadro.minecraft.storagedrawers.block;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.INetworked;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityController;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
 import com.jaquadro.minecraft.storagedrawers.core.ModItems;
 import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
@@ -48,8 +48,8 @@ public class BlockController extends HorizontalDirectionalBlock implements INetw
     @NotNull
     public InteractionResult use (@NotNull BlockState state, @NotNull Level level, @NotNull BlockPos pos, @NotNull Player player, @NotNull InteractionHand hand, @NotNull BlockHitResult hit) {
         Direction blockDir = state.getValue(FACING);
-        BlockEntityController blockEntity = WorldUtils.getBlockEntity(level, pos, BlockEntityController.class);
-        if (blockEntity == null)
+        TileEntityController tileEntityController = WorldUtils.getBlockEntity(level, pos, TileEntityController.class);
+        if (tileEntityController == null)
             return InteractionResult.FAIL;
 
         ItemStack item = player.getInventory().getSelected();
@@ -61,9 +61,9 @@ public class BlockController extends HorizontalDirectionalBlock implements INetw
 
         if (!level.isClientSide) {
             if (CommonConfig.GENERAL.debugTrace.get() && item.isEmpty())
-                blockEntity.printDebugInfo();
+                tileEntityController.printDebugInfo();
 
-            blockEntity.interactPutItemsIntoInventory(player);
+            tileEntityController.interactPutItemsIntoInventory(player);
         }
 
         return InteractionResult.SUCCESS;
@@ -91,14 +91,14 @@ public class BlockController extends HorizontalDirectionalBlock implements INetw
         if (level.isClientSide)
             return;
 
-        BlockEntityController blockEntity = WorldUtils.getBlockEntity(level, pos, BlockEntityController.class);
-        if (blockEntity == null)
+        TileEntityController tileEntityController = WorldUtils.getBlockEntity(level, pos, TileEntityController.class);
+        if (tileEntityController == null)
             return;
 
         switch (keyType) {
-            case DRAWER -> blockEntity.toggleLock(EnumSet.allOf(LockAttribute.class), LockAttribute.LOCK_POPULATED, player.getGameProfile());
-            case CONCEALMENT -> blockEntity.toggleShroud(player.getGameProfile());
-            case QUANTIFY -> blockEntity.toggleQuantified(player.getGameProfile());
+            case DRAWER -> tileEntityController.toggleLock(EnumSet.allOf(LockAttribute.class), LockAttribute.LOCK_POPULATED, player.getGameProfile());
+            case CONCEALMENT -> tileEntityController.toggleShroud(player.getGameProfile());
+            case QUANTIFY -> tileEntityController.toggleQuantified(player.getGameProfile());
 
             //case PERSONAL:
             //    String securityKey = ModItems.personalKey.getSecurityProviderKey(0);
@@ -114,17 +114,17 @@ public class BlockController extends HorizontalDirectionalBlock implements INetw
         if (world.isClientSide)
             return;
 
-        BlockEntityController blockEntity = WorldUtils.getBlockEntity(world, pos, BlockEntityController.class);
-        if (blockEntity == null)
+        TileEntityController tileEntityController = WorldUtils.getBlockEntity(world, pos, TileEntityController.class);
+        if (tileEntityController == null)
             return;
 
-        blockEntity.updateCache();
+        tileEntityController.updateCache();
 
         world.scheduleTick(pos, this, 100);
     }
 
     @Override
-    public BlockEntityController newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
-        return new BlockEntityController(pos, state);
+    public TileEntityController newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
+        return new TileEntityController(pos, state);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockController.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockController.java
@@ -2,7 +2,7 @@ package com.jaquadro.minecraft.storagedrawers.block;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.INetworked;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityController;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
 import com.jaquadro.minecraft.storagedrawers.core.ModItems;
 import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
@@ -48,8 +48,8 @@ public class BlockController extends HorizontalDirectionalBlock implements INetw
     @NotNull
     public InteractionResult use (@NotNull BlockState state, @NotNull Level level, @NotNull BlockPos pos, @NotNull Player player, @NotNull InteractionHand hand, @NotNull BlockHitResult hit) {
         Direction blockDir = state.getValue(FACING);
-        TileEntityController tileEntityController = WorldUtils.getBlockEntity(level, pos, TileEntityController.class);
-        if (tileEntityController == null)
+        BlockEntityController blockEntity = WorldUtils.getBlockEntity(level, pos, BlockEntityController.class);
+        if (blockEntity == null)
             return InteractionResult.FAIL;
 
         ItemStack item = player.getInventory().getSelected();
@@ -61,9 +61,9 @@ public class BlockController extends HorizontalDirectionalBlock implements INetw
 
         if (!level.isClientSide) {
             if (CommonConfig.GENERAL.debugTrace.get() && item.isEmpty())
-                tileEntityController.printDebugInfo();
+                blockEntity.printDebugInfo();
 
-            tileEntityController.interactPutItemsIntoInventory(player);
+            blockEntity.interactPutItemsIntoInventory(player);
         }
 
         return InteractionResult.SUCCESS;
@@ -91,14 +91,14 @@ public class BlockController extends HorizontalDirectionalBlock implements INetw
         if (level.isClientSide)
             return;
 
-        TileEntityController tileEntityController = WorldUtils.getBlockEntity(level, pos, TileEntityController.class);
-        if (tileEntityController == null)
+        BlockEntityController blockEntity = WorldUtils.getBlockEntity(level, pos, BlockEntityController.class);
+        if (blockEntity == null)
             return;
 
         switch (keyType) {
-            case DRAWER -> tileEntityController.toggleLock(EnumSet.allOf(LockAttribute.class), LockAttribute.LOCK_POPULATED, player.getGameProfile());
-            case CONCEALMENT -> tileEntityController.toggleShroud(player.getGameProfile());
-            case QUANTIFY -> tileEntityController.toggleQuantified(player.getGameProfile());
+            case DRAWER -> blockEntity.toggleLock(EnumSet.allOf(LockAttribute.class), LockAttribute.LOCK_POPULATED, player.getGameProfile());
+            case CONCEALMENT -> blockEntity.toggleShroud(player.getGameProfile());
+            case QUANTIFY -> blockEntity.toggleQuantified(player.getGameProfile());
 
             //case PERSONAL:
             //    String securityKey = ModItems.personalKey.getSecurityProviderKey(0);
@@ -114,17 +114,17 @@ public class BlockController extends HorizontalDirectionalBlock implements INetw
         if (world.isClientSide)
             return;
 
-        TileEntityController tileEntityController = WorldUtils.getBlockEntity(world, pos, TileEntityController.class);
-        if (tileEntityController == null)
+        BlockEntityController blockEntity = WorldUtils.getBlockEntity(world, pos, BlockEntityController.class);
+        if (blockEntity == null)
             return;
 
-        tileEntityController.updateCache();
+        blockEntity.updateCache();
 
         world.scheduleTick(pos, this, 100);
     }
 
     @Override
-    public TileEntityController newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
-        return new TileEntityController(pos, state);
+    public BlockEntityController newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
+        return new BlockEntityController(pos, state);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -3,7 +3,7 @@ package com.jaquadro.minecraft.storagedrawers.block;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.storage.*;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
@@ -166,13 +166,13 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
 
     @Override
     public void setPlacedBy (@NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState state, @Nullable LivingEntity entity, @NotNull ItemStack stack) {
-        TileEntityDrawers tileEntityDrawers = WorldUtils.getBlockEntity(world, pos, TileEntityDrawers.class);
-        if (tileEntityDrawers == null)
+        BlockEntityDrawers blockEntity = WorldUtils.getBlockEntity(world, pos, BlockEntityDrawers.class);
+        if (blockEntity == null)
             return;
 
         CompoundTag tag = stack.getTagElement("tile");
         if (tag != null) {
-            tileEntityDrawers.readPortable(tag);
+            blockEntity.readPortable(tag);
         }
 
 //        if (stack.hasCustomHoverName()) {
@@ -180,7 +180,7 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
 //        }
 
         if (entity != null && entity.getOffhandItem().getItem() == ModItems.DRAWER_KEY.get()) {
-            IDrawerAttributes _attrs = tileEntityDrawers.getCapability(CapabilityDrawerAttributes.DRAWER_ATTRIBUTES_CAPABILITY).orElse(new EmptyDrawerAttributes());
+            IDrawerAttributes _attrs = blockEntity.getCapability(CapabilityDrawerAttributes.DRAWER_ATTRIBUTES_CAPABILITY).orElse(new EmptyDrawerAttributes());
             if (_attrs instanceof IDrawerAttributesModifiable attrs) {
                 attrs.setItemLocked(LockAttribute.LOCK_EMPTY, true);
                 attrs.setItemLocked(LockAttribute.LOCK_POPULATED, true);
@@ -200,8 +200,8 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
             return InteractionResult.PASS;
         }
 
-        TileEntityDrawers tileEntityDrawers = WorldUtils.getBlockEntity(level, pos, TileEntityDrawers.class);
-        if (tileEntityDrawers == null)
+        BlockEntityDrawers blockEntityDrawers = WorldUtils.getBlockEntity(level, pos, BlockEntityDrawers.class);
+        if (blockEntityDrawers == null)
             return InteractionResult.FAIL;
 
         //if (!SecurityManager.hasAccess(player.getGameProfile(), tileDrawers))
@@ -218,14 +218,14 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
                 return InteractionResult.PASS;
 
             if (item.getItem() instanceof ItemUpgrade) {
-                if (!tileEntityDrawers.upgrades().canAddUpgrade(item)) {
+                if (!blockEntityDrawers.upgrades().canAddUpgrade(item)) {
                     if (!level.isClientSide)
                         player.displayClientMessage(new TranslatableComponent("message.storagedrawers.cannot_add_upgrade"), true);
 
                     return InteractionResult.PASS;
                 }
 
-                if (!tileEntityDrawers.upgrades().addUpgrade(item)) {
+                if (!blockEntityDrawers.upgrades().addUpgrade(item)) {
                     if (!level.isClientSide)
                         player.displayClientMessage(new TranslatableComponent("message.storagedrawers.max_upgrades"), true);
 
@@ -266,13 +266,13 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
                     @Override
                     public AbstractContainerMenu createMenu (int windowId, @NotNull Inventory playerInv, @NotNull Player playerEntity) {
                         if (drawerCount == 1)
-                            return new ContainerDrawers1(windowId, playerInv, tileEntityDrawers);
+                            return new ContainerDrawers1(windowId, playerInv, blockEntityDrawers);
                         else if (drawerCount == 2)
-                            return new ContainerDrawers2(windowId, playerInv, tileEntityDrawers);
+                            return new ContainerDrawers2(windowId, playerInv, blockEntityDrawers);
                         else if (drawerCount == 4)
-                            return new ContainerDrawers4(windowId, playerInv, tileEntityDrawers);
+                            return new ContainerDrawers4(windowId, playerInv, blockEntityDrawers);
                         else if (drawerCount == 3 && BlockDrawers.this instanceof BlockCompDrawers)
-                            return new ContainerDrawersComp(windowId, playerInv, tileEntityDrawers);
+                            return new ContainerDrawersComp(windowId, playerInv, blockEntityDrawers);
                         return null;
                     }
                 }, extraData -> extraData.writeBlockPos(pos));
@@ -286,7 +286,7 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
         if (slot < 0)
             return InteractionResult.PASS;
 
-        tileEntityDrawers.interactPutItemsIntoSlot(slot, player);
+        blockEntityDrawers.interactPutItemsIntoSlot(slot, player);
 
         if (item.isEmpty())
             player.setItemInHand(hand, ItemStack.EMPTY);
@@ -350,8 +350,8 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
         if (!(state.getBlock() instanceof BlockDrawers))
             return false;
 
-        TileEntityDrawers tileEntityDrawers = WorldUtils.getBlockEntity(level, blockPos, TileEntityDrawers.class);
-        if (tileEntityDrawers == null)
+        BlockEntityDrawers blockEntityDrawers = WorldUtils.getBlockEntity(level, blockPos, BlockEntityDrawers.class);
+        if (blockEntityDrawers == null)
             return false;
 
         BlockHitResult hit = WorldUtils.rayTraceEyes(level, player, blockPos);
@@ -367,15 +367,15 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
         if (slot < 0)
             return false;
 
-        IDrawer drawer = tileEntityDrawers.getDrawer(slot);
+        IDrawer drawer = blockEntityDrawers.getDrawer(slot);
 
         ItemStack item;
         boolean invertShift = ClientConfig.GENERAL.invertShift.get();
 
         if (player.isShiftKeyDown() != invertShift)
-            item = tileEntityDrawers.takeItemsFromSlot(slot, drawer.getStoredItemStackSize());
+            item = blockEntityDrawers.takeItemsFromSlot(slot, drawer.getStoredItemStackSize());
         else
-            item = tileEntityDrawers.takeItemsFromSlot(slot, 1);
+            item = blockEntityDrawers.takeItemsFromSlot(slot, 1);
 
         if (CommonConfig.GENERAL.debugTrace.get())
             StorageDrawers.log.info((item.isEmpty()) ? "  null item" : "  " + item);
@@ -402,11 +402,11 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
     @NotNull
     public List<ItemStack> getDrops (@NotNull BlockState state, LootContext.Builder builder) {
         List<ItemStack> items = new ArrayList<>();
-        items.add(getMainDrop(state, (TileEntityDrawers)builder.getOptionalParameter(LootContextParams.BLOCK_ENTITY)));
+        items.add(getMainDrop(state, (BlockEntityDrawers)builder.getOptionalParameter(LootContextParams.BLOCK_ENTITY)));
         return items;
     }
 
-    protected ItemStack getMainDrop (BlockState state, TileEntityDrawers tile) {
+    protected ItemStack getMainDrop (BlockState state, BlockEntityDrawers tile) {
         ItemStack drop = new ItemStack(this);
         if (tile == null)
             return drop;
@@ -448,11 +448,11 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
         if (!isSignalSource(state))
             return 0;
 
-        TileEntityDrawers tileEntityDrawers = WorldUtils.getBlockEntity(blockAccess, pos, TileEntityDrawers.class);
-        if (tileEntityDrawers == null || !tileEntityDrawers.isRedstone())
+        BlockEntityDrawers blockEntity = WorldUtils.getBlockEntity(blockAccess, pos, BlockEntityDrawers.class);
+        if (blockEntity == null || !blockEntity.isRedstone())
             return 0;
 
-        return tileEntityDrawers.getRedstoneLevel();
+        return blockEntity.getRedstoneLevel();
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -3,7 +3,7 @@ package com.jaquadro.minecraft.storagedrawers.block;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.storage.*;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
@@ -166,13 +166,13 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
 
     @Override
     public void setPlacedBy (@NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState state, @Nullable LivingEntity entity, @NotNull ItemStack stack) {
-        BlockEntityDrawers blockEntity = WorldUtils.getBlockEntity(world, pos, BlockEntityDrawers.class);
-        if (blockEntity == null)
+        TileEntityDrawers tileEntityDrawers = WorldUtils.getBlockEntity(world, pos, TileEntityDrawers.class);
+        if (tileEntityDrawers == null)
             return;
 
         CompoundTag tag = stack.getTagElement("tile");
         if (tag != null) {
-            blockEntity.readPortable(tag);
+            tileEntityDrawers.readPortable(tag);
         }
 
 //        if (stack.hasCustomHoverName()) {
@@ -180,7 +180,7 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
 //        }
 
         if (entity != null && entity.getOffhandItem().getItem() == ModItems.DRAWER_KEY.get()) {
-            IDrawerAttributes _attrs = blockEntity.getCapability(CapabilityDrawerAttributes.DRAWER_ATTRIBUTES_CAPABILITY).orElse(new EmptyDrawerAttributes());
+            IDrawerAttributes _attrs = tileEntityDrawers.getCapability(CapabilityDrawerAttributes.DRAWER_ATTRIBUTES_CAPABILITY).orElse(new EmptyDrawerAttributes());
             if (_attrs instanceof IDrawerAttributesModifiable attrs) {
                 attrs.setItemLocked(LockAttribute.LOCK_EMPTY, true);
                 attrs.setItemLocked(LockAttribute.LOCK_POPULATED, true);
@@ -200,8 +200,8 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
             return InteractionResult.PASS;
         }
 
-        BlockEntityDrawers blockEntityDrawers = WorldUtils.getBlockEntity(level, pos, BlockEntityDrawers.class);
-        if (blockEntityDrawers == null)
+        TileEntityDrawers tileEntityDrawers = WorldUtils.getBlockEntity(level, pos, TileEntityDrawers.class);
+        if (tileEntityDrawers == null)
             return InteractionResult.FAIL;
 
         //if (!SecurityManager.hasAccess(player.getGameProfile(), tileDrawers))
@@ -218,14 +218,14 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
                 return InteractionResult.PASS;
 
             if (item.getItem() instanceof ItemUpgrade) {
-                if (!blockEntityDrawers.upgrades().canAddUpgrade(item)) {
+                if (!tileEntityDrawers.upgrades().canAddUpgrade(item)) {
                     if (!level.isClientSide)
                         player.displayClientMessage(new TranslatableComponent("message.storagedrawers.cannot_add_upgrade"), true);
 
                     return InteractionResult.PASS;
                 }
 
-                if (!blockEntityDrawers.upgrades().addUpgrade(item)) {
+                if (!tileEntityDrawers.upgrades().addUpgrade(item)) {
                     if (!level.isClientSide)
                         player.displayClientMessage(new TranslatableComponent("message.storagedrawers.max_upgrades"), true);
 
@@ -266,13 +266,13 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
                     @Override
                     public AbstractContainerMenu createMenu (int windowId, @NotNull Inventory playerInv, @NotNull Player playerEntity) {
                         if (drawerCount == 1)
-                            return new ContainerDrawers1(windowId, playerInv, blockEntityDrawers);
+                            return new ContainerDrawers1(windowId, playerInv, tileEntityDrawers);
                         else if (drawerCount == 2)
-                            return new ContainerDrawers2(windowId, playerInv, blockEntityDrawers);
+                            return new ContainerDrawers2(windowId, playerInv, tileEntityDrawers);
                         else if (drawerCount == 4)
-                            return new ContainerDrawers4(windowId, playerInv, blockEntityDrawers);
+                            return new ContainerDrawers4(windowId, playerInv, tileEntityDrawers);
                         else if (drawerCount == 3 && BlockDrawers.this instanceof BlockCompDrawers)
-                            return new ContainerDrawersComp(windowId, playerInv, blockEntityDrawers);
+                            return new ContainerDrawersComp(windowId, playerInv, tileEntityDrawers);
                         return null;
                     }
                 }, extraData -> extraData.writeBlockPos(pos));
@@ -286,7 +286,7 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
         if (slot < 0)
             return InteractionResult.PASS;
 
-        blockEntityDrawers.interactPutItemsIntoSlot(slot, player);
+        tileEntityDrawers.interactPutItemsIntoSlot(slot, player);
 
         if (item.isEmpty())
             player.setItemInHand(hand, ItemStack.EMPTY);
@@ -350,8 +350,8 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
         if (!(state.getBlock() instanceof BlockDrawers))
             return false;
 
-        BlockEntityDrawers blockEntityDrawers = WorldUtils.getBlockEntity(level, blockPos, BlockEntityDrawers.class);
-        if (blockEntityDrawers == null)
+        TileEntityDrawers tileEntityDrawers = WorldUtils.getBlockEntity(level, blockPos, TileEntityDrawers.class);
+        if (tileEntityDrawers == null)
             return false;
 
         BlockHitResult hit = WorldUtils.rayTraceEyes(level, player, blockPos);
@@ -367,15 +367,15 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
         if (slot < 0)
             return false;
 
-        IDrawer drawer = blockEntityDrawers.getDrawer(slot);
+        IDrawer drawer = tileEntityDrawers.getDrawer(slot);
 
         ItemStack item;
         boolean invertShift = ClientConfig.GENERAL.invertShift.get();
 
         if (player.isShiftKeyDown() != invertShift)
-            item = blockEntityDrawers.takeItemsFromSlot(slot, drawer.getStoredItemStackSize());
+            item = tileEntityDrawers.takeItemsFromSlot(slot, drawer.getStoredItemStackSize());
         else
-            item = blockEntityDrawers.takeItemsFromSlot(slot, 1);
+            item = tileEntityDrawers.takeItemsFromSlot(slot, 1);
 
         if (CommonConfig.GENERAL.debugTrace.get())
             StorageDrawers.log.info((item.isEmpty()) ? "  null item" : "  " + item);
@@ -402,11 +402,11 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
     @NotNull
     public List<ItemStack> getDrops (@NotNull BlockState state, LootContext.Builder builder) {
         List<ItemStack> items = new ArrayList<>();
-        items.add(getMainDrop(state, (BlockEntityDrawers)builder.getOptionalParameter(LootContextParams.BLOCK_ENTITY)));
+        items.add(getMainDrop(state, (TileEntityDrawers)builder.getOptionalParameter(LootContextParams.BLOCK_ENTITY)));
         return items;
     }
 
-    protected ItemStack getMainDrop (BlockState state, BlockEntityDrawers tile) {
+    protected ItemStack getMainDrop (BlockState state, TileEntityDrawers tile) {
         ItemStack drop = new ItemStack(this);
         if (tile == null)
             return drop;
@@ -448,11 +448,11 @@ public abstract class BlockDrawers extends HorizontalDirectionalBlock implements
         if (!isSignalSource(state))
             return 0;
 
-        BlockEntityDrawers blockEntity = WorldUtils.getBlockEntity(blockAccess, pos, BlockEntityDrawers.class);
-        if (blockEntity == null || !blockEntity.isRedstone())
+        TileEntityDrawers tileEntityDrawers = WorldUtils.getBlockEntity(blockAccess, pos, TileEntityDrawers.class);
+        if (tileEntityDrawers == null || !tileEntityDrawers.isRedstone())
             return 0;
 
-        return blockEntity.getRedstoneLevel();
+        return tileEntityDrawers.getRedstoneLevel();
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockKeyButton.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockKeyButton.java
@@ -24,7 +24,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Random;
 
 public class BlockKeyButton extends Block implements ITileEntityProvider

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockSlave.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockSlave.java
@@ -1,17 +1,16 @@
 package com.jaquadro.minecraft.storagedrawers.block;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.INetworked;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntitySlave;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.EntityBlock;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntitySlave;
+import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
-
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockSlave extends Block implements INetworked, EntityBlock
 {
@@ -20,38 +19,22 @@ public class BlockSlave extends Block implements INetworked, EntityBlock
     }
 
     public void toggle (Level world, BlockPos pos, Player player, EnumKeyType keyType) {
-        TileEntitySlave tile = getTileEntity(world, pos);
-        if (tile == null)
+        BlockEntitySlave blockEntity = WorldUtils.getBlockEntity(world, pos, BlockEntitySlave.class);
+        if (blockEntity == null)
             return;
 
-        BlockPos controllerPos = tile.getControllerPos();
+        BlockPos controllerPos = blockEntity.getControllerPos();
         if (controllerPos == null)
             return;
 
         Block block = world.getBlockState(controllerPos).getBlock();
-        if (block instanceof BlockController) {
-            BlockController controller = (BlockController)block;
-            controller.toggle(world, controllerPos, player, keyType);
+        if (block instanceof BlockController blockController) {
+            blockController.toggle(world, controllerPos, player, keyType);
         }
     }
 
     @Override
-    public TileEntitySlave newBlockEntity (BlockPos pos, BlockState state) {
-        return new TileEntitySlave(pos, state);
-    }
-
-    public TileEntitySlave getTileEntity (BlockGetter blockAccess, BlockPos pos) {
-        BlockEntity tile = blockAccess.getBlockEntity(pos);
-        return (tile instanceof TileEntitySlave) ? (TileEntitySlave) tile : null;
-    }
-
-    public TileEntitySlave getTileEntitySafe (Level world, BlockPos pos) {
-        TileEntitySlave tile = getTileEntity(world, pos);
-        if (tile == null) {
-            tile = newBlockEntity(pos, world.getBlockState(pos));
-            world.setBlockEntity(tile);
-        }
-
-        return tile;
+    public BlockEntitySlave newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
+        return new BlockEntitySlave(pos, state);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockSlave.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockSlave.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.block;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.INetworked;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntitySlave;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntitySlave;
 import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
@@ -19,11 +19,11 @@ public class BlockSlave extends Block implements INetworked, EntityBlock
     }
 
     public void toggle (Level world, BlockPos pos, Player player, EnumKeyType keyType) {
-        TileEntitySlave tileEntitySlave = WorldUtils.getBlockEntity(world, pos, TileEntitySlave.class);
-        if (tileEntitySlave == null)
+        BlockEntitySlave blockEntity = WorldUtils.getBlockEntity(world, pos, BlockEntitySlave.class);
+        if (blockEntity == null)
             return;
 
-        BlockPos controllerPos = tileEntitySlave.getControllerPos();
+        BlockPos controllerPos = blockEntity.getControllerPos();
         if (controllerPos == null)
             return;
 
@@ -34,7 +34,7 @@ public class BlockSlave extends Block implements INetworked, EntityBlock
     }
 
     @Override
-    public TileEntitySlave newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
-        return new TileEntitySlave(pos, state);
+    public BlockEntitySlave newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
+        return new BlockEntitySlave(pos, state);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockSlave.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockSlave.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.block;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.INetworked;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntitySlave;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntitySlave;
 import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
@@ -19,11 +19,11 @@ public class BlockSlave extends Block implements INetworked, EntityBlock
     }
 
     public void toggle (Level world, BlockPos pos, Player player, EnumKeyType keyType) {
-        BlockEntitySlave blockEntity = WorldUtils.getBlockEntity(world, pos, BlockEntitySlave.class);
-        if (blockEntity == null)
+        TileEntitySlave tileEntitySlave = WorldUtils.getBlockEntity(world, pos, TileEntitySlave.class);
+        if (tileEntitySlave == null)
             return;
 
-        BlockPos controllerPos = blockEntity.getControllerPos();
+        BlockPos controllerPos = tileEntitySlave.getControllerPos();
         if (controllerPos == null)
             return;
 
@@ -34,7 +34,7 @@ public class BlockSlave extends Block implements INetworked, EntityBlock
     }
 
     @Override
-    public BlockEntitySlave newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
-        return new BlockEntitySlave(pos, state);
+    public TileEntitySlave newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
+        return new TileEntitySlave(pos, state);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockStandardDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockStandardDrawers.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.block;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawersStandard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -50,7 +50,7 @@ public class BlockStandardDrawers extends BlockDrawers
 
     @Override
     @Nullable
-    public TileEntityDrawers newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
-        return TileEntityDrawersStandard.createEntity(getDrawerCount(), pos, state);
+    public BlockEntityDrawers newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
+        return BlockEntityDrawersStandard.createEntity(getDrawerCount(), pos, state);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockStandardDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockStandardDrawers.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.block;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawersStandard;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -50,7 +50,7 @@ public class BlockStandardDrawers extends BlockDrawers
 
     @Override
     @Nullable
-    public BlockEntityDrawers newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
-        return BlockEntityDrawersStandard.createEntity(getDrawerCount(), pos, state);
+    public TileEntityDrawers newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
+        return TileEntityDrawersStandard.createEntity(getDrawerCount(), pos, state);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockStandardDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockStandardDrawers.java
@@ -1,25 +1,17 @@
 package com.jaquadro.minecraft.storagedrawers.block;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.core.Direction;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawersStandard;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.level.BlockGetter;
-
-import java.util.Vector;
-
+import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class BlockStandardDrawers extends BlockDrawers
 {
-    //public static final EnumProperty<EnumBasicDrawer> BLOCK = EnumProperty.create("block", EnumBasicDrawer.class);
-
-
-    //@SideOnly(Side.CLIENT)
-    //private StatusModelData[] statusInfo;
 
     public BlockStandardDrawers (int drawerCount, boolean halfDepth, int storageUnits, BlockBehaviour.Properties properties) {
        super(drawerCount, halfDepth, storageUnits, properties);
@@ -33,43 +25,32 @@ public class BlockStandardDrawers extends BlockDrawers
         return halfDepth ? 4 / drawerCount : 8 / drawerCount;
     }
 
-    /*@Override
-    @SideOnly(Side.CLIENT)
-    public void initDynamic () {
-        statusInfo = new StatusModelData[EnumBasicDrawer.values().length];
-        for (EnumBasicDrawer type : EnumBasicDrawer.values()) {
-            ResourceLocation location = new ResourceLocation(StorageDrawers.MOD_ID + ":models/dynamic/basicDrawers_" + type.getName() + ".json");
-            statusInfo[type.getMetadata()] = new StatusModelData(type.getDrawerCount(), location);
-        }
-    }
-
     @Override
-    @SideOnly(Side.CLIENT)
-    public StatusModelData getStatusInfo (IBlockState state) {
-        if (state != null) {
-            EnumBasicDrawer info = state.getValue(BLOCK);
-            if (info != null)
-                return statusInfo[info.getMetadata()];
-        }
+    protected int getDrawerSlot (Direction correctSide, @NotNull Vec3 normalizedHit) {
+        if (!hitAny(correctSide, normalizedHit))
+            return super.getDrawerSlot(correctSide, normalizedHit);
 
-        return null;
-    }*/
-
-    @Override
-    protected int getDrawerSlot (Direction side, Vec3 hit) {
         if (getDrawerCount() == 1)
             return 0;
-        if (getDrawerCount() == 2)
-            return hitTop(hit.y) ? 0 : 1;
 
-        if (hitLeft(side, hit.x, hit.z))
-            return hitTop(hit.y) ? 0 : 2;
-        else
-            return hitTop(hit.y) ? 1 : 3;
+        boolean hitTop = hitTop(normalizedHit);
+
+        if (getDrawerCount() == 2)
+            return hitTop ? 0 : 1;
+
+        if (getDrawerCount() == 4) {
+            if (hitLeft(correctSide, normalizedHit))
+                return hitTop ? 0 : 2;
+            else
+                return hitTop ? 1 : 3;
+        }
+
+        return super.getDrawerSlot(correctSide, normalizedHit);
     }
 
     @Override
-    public TileEntityDrawers newBlockEntity (BlockPos pos, BlockState state) {
-        return TileEntityDrawersStandard.createEntity(getDrawerCount(), pos, state);
+    @Nullable
+    public BlockEntityDrawers newBlockEntity (@NotNull BlockPos pos, @NotNull BlockState state) {
+        return BlockEntityDrawersStandard.createEntity(getDrawerCount(), pos, state);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockTrim.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockTrim.java
@@ -2,7 +2,6 @@ package com.jaquadro.minecraft.storagedrawers.block;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.INetworked;
 import net.minecraft.world.level.block.Block;
-
 import net.minecraft.world.level.block.state.BlockBehaviour;
 
 public class BlockTrim extends Block implements INetworked

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/EnumCompDrawer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/EnumCompDrawer.java
@@ -2,6 +2,7 @@ package com.jaquadro.minecraft.storagedrawers.block;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGeometry;
 import net.minecraft.util.StringRepresentable;
+import org.jetbrains.annotations.NotNull;
 
 public enum EnumCompDrawer implements IDrawerGeometry, StringRepresentable
 {
@@ -56,6 +57,7 @@ public enum EnumCompDrawer implements IDrawerGeometry, StringRepresentable
     }
 
     @Override
+    @NotNull
     public String getSerializedName () {
         return name;
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/EnumKeyType.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/EnumKeyType.java
@@ -1,8 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.block;
 
 import net.minecraft.util.StringRepresentable;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public enum EnumKeyType implements StringRepresentable
 {
@@ -32,7 +31,7 @@ public enum EnumKeyType implements StringRepresentable
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public String getSerializedName () {
         return name;
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BaseBlockEntity.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BaseBlockEntity.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.block.tile;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.TileDataShim;
+import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.BlockEntityDataShim;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
@@ -15,13 +15,13 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ChamTileEntity extends BlockEntity
+public class BaseBlockEntity extends BlockEntity
 {
     private CompoundTag failureSnapshot;
-    private List<TileDataShim> fixedShims;
-    private List<TileDataShim> portableShims;
+    private List<BlockEntityDataShim> fixedShims;
+    private List<BlockEntityDataShim> portableShims;
 
-    public ChamTileEntity(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+    public BaseBlockEntity(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(blockEntityType, pos, state);
     }
 
@@ -33,13 +33,13 @@ public class ChamTileEntity extends BlockEntity
         return false;
     }
 
-    public void injectData (TileDataShim shim) {
+    public void injectData (BlockEntityDataShim shim) {
         if (fixedShims == null)
             fixedShims = new ArrayList<>();
         fixedShims.add(shim);
     }
 
-    public void injectPortableData (TileDataShim shim) {
+    public void injectPortableData (BlockEntityDataShim shim) {
         if (portableShims == null)
             portableShims = new ArrayList<>();
         portableShims.add(shim);
@@ -92,14 +92,14 @@ public class ChamTileEntity extends BlockEntity
 
     public void readPortable (CompoundTag tag) {
         if (portableShims != null) {
-            for (TileDataShim shim : portableShims)
+            for (BlockEntityDataShim shim : portableShims)
                 shim.read(tag);
         }
     }
 
     public CompoundTag writePortable (CompoundTag tag) {
         if (portableShims != null) {
-            for (TileDataShim shim : portableShims)
+            for (BlockEntityDataShim shim : portableShims)
                 tag = shim.write(tag);
         }
 
@@ -108,14 +108,14 @@ public class ChamTileEntity extends BlockEntity
 
     protected void readFixed (CompoundTag tag) {
         if (fixedShims != null) {
-            for (TileDataShim shim : fixedShims)
+            for (BlockEntityDataShim shim : fixedShims)
                 shim.read(tag);
         }
     }
 
     protected CompoundTag writeFixed (CompoundTag tag) {
         if (fixedShims != null) {
-            for (TileDataShim shim : fixedShims)
+            for (BlockEntityDataShim shim : fixedShims)
                 tag = shim.write(tag);
         }
 
@@ -198,8 +198,8 @@ public class ChamTileEntity extends BlockEntity
     public void invalidateCaps() {
         super.invalidateCaps();
         if (fixedShims != null)
-            fixedShims.forEach(TileDataShim::invalidateCaps);
+            fixedShims.forEach(BlockEntityDataShim::invalidateCaps);
         if (portableShims != null)
-            portableShims.forEach(TileDataShim::invalidateCaps);
+            portableShims.forEach(BlockEntityDataShim::invalidateCaps);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityController.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityController.java
@@ -14,6 +14,7 @@ import com.jaquadro.minecraft.storagedrawers.core.ModBlockEntities;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
 import com.jaquadro.minecraft.storagedrawers.security.SecurityManager;
 import com.jaquadro.minecraft.storagedrawers.util.ItemCollectionRegistry;
+import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -30,13 +31,13 @@ import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.IItemHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Predicate;
 
-public class TileEntityController extends ChamTileEntity implements IDrawerGroup
+public class BlockEntityController extends BaseBlockEntity implements IDrawerGroup
 {
     public static Capability<IDrawerAttributes> DRAWER_ATTRIBUTES_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
@@ -95,9 +96,9 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
         }
     }
 
-    private Queue<BlockPos> searchQueue = new LinkedList<>();
-    private Set<BlockPos> searchDiscovered = new HashSet<>();
-    private Comparator<SlotRecord> slotRecordComparator = (o1, o2) -> o1.priority - o2.priority;
+    private final Queue<BlockPos> searchQueue = new LinkedList<>();
+    private final Set<BlockPos> searchDiscovered = new HashSet<>();
+    private final Comparator<SlotRecord> slotRecordComparator = Comparator.comparingInt(o -> o.priority);
 
     private IDrawerAttributes getAttributes (Object obj) {
         IDrawerAttributes attrs = EmptyDrawerAttributes.EMPTY;
@@ -140,37 +141,39 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
         return PRI_NORMAL;
     }
 
-    private Map<BlockPos, StorageRecord> storage = new HashMap<>();
+    private final Map<BlockPos, StorageRecord> storage = new HashMap<>();
     protected List<SlotRecord> drawerSlotList = new ArrayList<>();
 
-    private ItemCollectionRegistry<SlotRecord> drawerPrimaryLookup = new ItemCollectionRegistry<>();
+    private final ItemCollectionRegistry<SlotRecord> drawerPrimaryLookup = new ItemCollectionRegistry<>();
 
     protected int[] drawerSlots = new int[0];
-    private int range;
+    private final int range;
 
     private long lastUpdateTime;
     private long lastClickTime;
     private UUID lastClickUUID;
 
-    protected TileEntityController (BlockEntityType<?> tileEntityType, BlockPos pos, BlockState state) {
-        super(tileEntityType, pos, state);
+    protected BlockEntityController(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+        super(blockEntityType, pos, state);
         range = CommonConfig.GENERAL.controllerRange.get();
     }
 
-    public TileEntityController (BlockPos pos, BlockState state) {
+    public BlockEntityController(BlockPos pos, BlockState state) {
         this(ModBlockEntities.CONTROLLER.get(), pos, state);
     }
 
     public void printDebugInfo () {
-        StorageDrawers.log.info("Controller at " + worldPosition.toString());
+        StorageDrawers.log.info("Controller at " + worldPosition);
         StorageDrawers.log.info("  Range: " + range + " blocks");
         StorageDrawers.log.info("  Stored records: " + storage.size() + ", slot list: " + drawerSlots.length);
-        StorageDrawers.log.info("  Ticks since last update: " + (getLevel().getGameTime() - lastUpdateTime));
+        StorageDrawers.log.info("  Ticks since last update: " + (getLevel() == null ? "null" : (getLevel().getGameTime() - lastUpdateTime)));
     }
 
     @Override
     public void clearRemoved () {
         super.clearRemoved();
+        if (getLevel() == null)
+            return;
 
         if (!getLevel().getBlockTicks().hasScheduledTick(getBlockPos(), ModBlocks.CONTROLLER.get()))
             getLevel().scheduleTick(getBlockPos(), ModBlocks.CONTROLLER.get(), 1);
@@ -182,6 +185,9 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
     }
 
     public int interactPutItemsIntoInventory (Player player) {
+        if (getLevel() == null)
+            return 0;
+
         boolean dumpInventory = getLevel().getGameTime() - lastClickTime < 10 && player.getUUID().equals(lastClickUUID);
         int count = 0;
 
@@ -202,9 +208,6 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
                         player.getInventory().setItem(i, ItemStack.EMPTY);
                 }
             }
-
-            if (count > 0)
-                StorageDrawers.proxy.updatePlayerInventory(player);
         }
 
         lastClickTime = getLevel().getGameTime();
@@ -213,7 +216,7 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
         return count;
     }
 
-    protected int insertItems (@Nonnull ItemStack stack, GameProfile profile) {
+    protected int insertItems (@NotNull ItemStack stack, GameProfile profile) {
         int remainder = new ProtectedItemRepository(this, profile).insertItem(stack, false).getCount();
         int added = stack.getCount() - remainder;
 
@@ -229,8 +232,7 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
             if (record.storage == null)
                 continue;
 
-            if (record.storage instanceof IProtectable) {
-                IProtectable protectable = (IProtectable)record.storage;
+            if (record.storage instanceof IProtectable protectable) {
                 if (!SecurityManager.hasOwnership(profile, protectable))
                     continue;
 
@@ -240,7 +242,6 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
                     if (template.getOwner() == null)
                         state = profile.getId();
                     else {
-                        state = null;
                         provider = null;
                     }
                 }
@@ -265,10 +266,9 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
             }
 
             IDrawerAttributes attrs = getAttributes(record.storage);
-            if (!(attrs instanceof IDrawerAttributesModifiable))
+            if (!(attrs instanceof IDrawerAttributesModifiable mattrs))
                 continue;
 
-            IDrawerAttributesModifiable mattrs = (IDrawerAttributesModifiable)attrs;
             if (template == null) {
                 template = mattrs.isConcealed();
                 state = !template;
@@ -291,10 +291,9 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
             }
 
             IDrawerAttributes attrs = getAttributes(record.storage);
-            if (!(attrs instanceof IDrawerAttributesModifiable))
+            if (!(attrs instanceof IDrawerAttributesModifiable mattrs))
                 continue;
 
-            IDrawerAttributesModifiable mattrs = (IDrawerAttributesModifiable)attrs;
             if (template == null) {
                 template = mattrs.isShowingQuantity();
                 state = !template;
@@ -317,10 +316,9 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
             }
 
             IDrawerAttributes attrs = getAttributes(record.storage);
-            if (!(attrs instanceof IDrawerAttributesModifiable))
+            if (!(attrs instanceof IDrawerAttributesModifiable mattrs))
                 continue;
 
-            IDrawerAttributesModifiable mattrs = (IDrawerAttributesModifiable)attrs;
             if (template == null) {
                 template = mattrs.isItemLocked(key);
                 state = !template;
@@ -345,6 +343,9 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
     }
 
     public void updateCache () {
+        if (getLevel() == null)
+            return;
+
         lastUpdateTime = getLevel().getGameTime();
         int preCount = drawerSlots.length;
 
@@ -377,7 +378,7 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
         indexSlotRecords(records);
 
         List<SlotRecord> copied = new ArrayList<>(records);
-        Collections.sort(copied, slotRecordComparator);
+        copied.sort(slotRecordComparator);
 
         int[] slotMap = new int[copied.size()];
         for (int i = 0; i < slotMap.length; i++)
@@ -437,15 +438,15 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
         }
     }
 
-    private void updateRecordInfo (BlockPos coord, StorageRecord record, BlockEntity te) {
-        if (te == null) {
+    private void updateRecordInfo (BlockPos coord, StorageRecord record, BlockEntity blockEntity) {
+        if (blockEntity == null) {
             if (record.storage != null)
                 clearRecordInfo(coord, record);
 
             return;
         }
 
-        if (te instanceof TileEntityController) {
+        if (blockEntity instanceof BlockEntityController) {
             if (record.storage == null && record.invStorageSize > 0)
                 return;
 
@@ -454,9 +455,9 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
 
             record.storage = null;
         }
-        else if (te instanceof TileEntitySlave) {
+        else if (blockEntity instanceof BlockEntitySlave) {
             if (record.storage == null && record.invStorageSize == 0) {
-                if (((TileEntitySlave) te).getController() == this)
+                if (((BlockEntitySlave) blockEntity).getController() == this)
                     return;
             }
 
@@ -465,10 +466,10 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
 
             record.storage = null;
 
-            ((TileEntitySlave) te).bindController(getBlockPos());
+            ((BlockEntitySlave) blockEntity).bindController(getBlockPos());
         }
-        else if (te instanceof TileEntityDrawers) {
-            IDrawerGroup group = ((TileEntityDrawers) te).getGroup();
+        else if (blockEntity instanceof BlockEntityDrawers) {
+            IDrawerGroup group = ((BlockEntityDrawers) blockEntity).getGroup();
             if (record.storage == group)
                 return;
 
@@ -482,7 +483,7 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
                 drawerSlotList.add(new SlotRecord(group, coord, i));
         }
         else {
-            IDrawerGroup group = te.getCapability(DRAWER_GROUP_CAPABILITY, null).orElse(null);
+            IDrawerGroup group = blockEntity.getCapability(DRAWER_GROUP_CAPABILITY, null).orElse(null);
             if (record.storage == group)
                 return;
 
@@ -500,6 +501,8 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
     }
 
     private void populateNodes (BlockPos root) {
+        if (getLevel() == null)
+            return;
 
         searchQueue.clear();
         searchQueue.add(root);
@@ -513,7 +516,7 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
             if (depth > range)
                 continue;
 
-            if (!getLevel().hasChunkAt(coord))
+            if (!getLevel().isLoaded(coord))
                 continue;
 
             Block block = getLevel().getBlockState(coord).getBlock();
@@ -527,7 +530,7 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
             }
 
             if (block instanceof BlockSlave) {
-                ((BlockSlave) block).getTileEntitySafe(getLevel(), coord);
+                WorldUtils.getBlockEntity(getLevel(), coord, BlockEntitySlave.class);
             }
 
             updateRecordInfo(coord, record, getLevel().getBlockEntity(coord));
@@ -563,8 +566,7 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
         if (group == null || !group.isGroupValid())
             return null;
 
-        if (group instanceof BlockEntity) {
-            BlockEntity tile = (BlockEntity)group;
+        if (group instanceof BlockEntity tile) {
             if (tile.isRemoved() || !tile.getBlockPos().equals(record.coord)) {
                 record.group = null;
                 return null;
@@ -604,7 +606,7 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public IDrawer getDrawer (int slot) {
         IDrawerGroup group = getGroupForDrawerSlot(slot);
         if (group == null)
@@ -613,7 +615,6 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
         return group.getDrawer(getLocalDrawerSlot(slot));
     }
 
-    @Nonnull
     @Override
     public int[] getAccessibleDrawerSlots () {
         return drawerSlots;
@@ -635,7 +636,8 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
     private final LazyOptional<?> capabilityGroup = LazyOptional.of(() -> this);
 
     @Override
-    public <T> LazyOptional<T> getCapability (@Nonnull Capability<T> capability, @Nullable Direction facing) {
+    @NotNull
+    public <T> LazyOptional<T> getCapability (@NotNull Capability<T> capability, @Nullable Direction facing) {
         if (capability == ITEM_HANDLER_CAPABILITY)
             return capabilityItemHandler.cast();
         if (capability == ITEM_REPOSITORY_CAPABILITY)
@@ -652,9 +654,9 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
             super(group);
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public ItemStack insertItem (@Nonnull ItemStack stack, boolean simulate, Predicate<ItemStack> predicate) {
+        public ItemStack insertItem (@NotNull ItemStack stack, boolean simulate, Predicate<ItemStack> predicate) {
             Collection<SlotRecord> primaryRecords = drawerPrimaryLookup.getEntries(stack.getItem());
             Set<Integer> checkedSlots = (simulate) ? new HashSet<>() : null;
 
@@ -711,9 +713,9 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
             return stackResult(stack, amount);
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public ItemStack extractItem (@Nonnull ItemStack stack, int amount, boolean simulate, Predicate<ItemStack> predicate) {
+        public ItemStack extractItem (@NotNull ItemStack stack, int amount, boolean simulate, Predicate<ItemStack> predicate) {
             Collection<SlotRecord> primaryRecords = drawerPrimaryLookup.getEntries(stack.getItem());
             Set<Integer> checkedSlots = (simulate) ? new HashSet<>() : null;
 
@@ -773,7 +775,7 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
 
     private class ProtectedItemRepository extends ItemRepository
     {
-        private GameProfile profile;
+        private final GameProfile profile;
 
         public ProtectedItemRepository (IDrawerGroup group, GameProfile profile) {
             super(group);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityController.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityController.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.function.Predicate;
 
-public class TileEntityController extends ChamTileEntity implements IDrawerGroup
+public class BlockEntityController extends BaseBlockEntity implements IDrawerGroup
 {
     public static Capability<IDrawerAttributes> DRAWER_ATTRIBUTES_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
@@ -153,12 +153,12 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
     private long lastClickTime;
     private UUID lastClickUUID;
 
-    protected TileEntityController(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+    protected BlockEntityController(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(blockEntityType, pos, state);
         range = CommonConfig.GENERAL.controllerRange.get();
     }
 
-    public TileEntityController(BlockPos pos, BlockState state) {
+    public BlockEntityController(BlockPos pos, BlockState state) {
         this(ModBlockEntities.CONTROLLER.get(), pos, state);
     }
 
@@ -446,7 +446,7 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
             return;
         }
 
-        if (blockEntity instanceof TileEntityController) {
+        if (blockEntity instanceof BlockEntityController) {
             if (record.storage == null && record.invStorageSize > 0)
                 return;
 
@@ -455,9 +455,9 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
 
             record.storage = null;
         }
-        else if (blockEntity instanceof TileEntitySlave) {
+        else if (blockEntity instanceof BlockEntitySlave) {
             if (record.storage == null && record.invStorageSize == 0) {
-                if (((TileEntitySlave) blockEntity).getController() == this)
+                if (((BlockEntitySlave) blockEntity).getController() == this)
                     return;
             }
 
@@ -466,10 +466,10 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
 
             record.storage = null;
 
-            ((TileEntitySlave) blockEntity).bindController(getBlockPos());
+            ((BlockEntitySlave) blockEntity).bindController(getBlockPos());
         }
-        else if (blockEntity instanceof TileEntityDrawers) {
-            IDrawerGroup group = ((TileEntityDrawers) blockEntity).getGroup();
+        else if (blockEntity instanceof BlockEntityDrawers) {
+            IDrawerGroup group = ((BlockEntityDrawers) blockEntity).getGroup();
             if (record.storage == group)
                 return;
 
@@ -530,7 +530,7 @@ public class TileEntityController extends ChamTileEntity implements IDrawerGroup
             }
 
             if (block instanceof BlockSlave) {
-                WorldUtils.getBlockEntity(getLevel(), coord, TileEntitySlave.class);
+                WorldUtils.getBlockEntity(getLevel(), coord, BlockEntitySlave.class);
             }
 
             updateRecordInfo(coord, record, getLevel().getBlockEntity(coord));

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityController.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityController.java
@@ -631,9 +631,9 @@ public class BlockEntityController extends BaseBlockEntity implements IDrawerGro
     private final DrawerItemHandler itemHandler = new DrawerItemHandler(this);
     private final ItemRepository itemRepository = new ItemRepository(this);
 
-    private final LazyOptional<?> capabilityItemHandler = LazyOptional.of(() -> itemHandler);
-    private final LazyOptional<?> capabilityItemRepository = LazyOptional.of(() -> itemRepository);
-    private final LazyOptional<?> capabilityGroup = LazyOptional.of(() -> this);
+    private final LazyOptional<IItemHandler> capabilityItemHandler = LazyOptional.of(() -> itemHandler);
+    private final LazyOptional<IItemRepository> capabilityItemRepository = LazyOptional.of(() -> itemRepository);
+    private final LazyOptional<IDrawerGroup> capabilityGroup = LazyOptional.of(() -> this);
 
     @Override
     @NotNull
@@ -646,6 +646,14 @@ public class BlockEntityController extends BaseBlockEntity implements IDrawerGro
             return capabilityGroup.cast();
 
         return super.getCapability(capability, facing);
+    }
+
+    @Override
+    public void invalidateCaps() {
+        super.invalidateCaps();
+        capabilityItemHandler.invalidate();
+        capabilityItemRepository.invalidate();
+        capabilityGroup.invalidate();
     }
 
     private class ItemRepository extends DrawerItemRepository

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawers.java
@@ -1,8 +1,10 @@
 package com.jaquadro.minecraft.storagedrawers.block.tile;
 
-import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.api.storage.*;
-import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.*;
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributes;
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributesModifiable;
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
+import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.UpgradeData;
 import com.jaquadro.minecraft.storagedrawers.capabilities.BasicDrawerAttributes;
@@ -21,7 +23,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.ModelDataManager;
@@ -34,13 +35,13 @@ import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.network.PacketDistributor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.UUID;
 
-public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawerGroup /* IProtectable, INameable */
+public abstract class BlockEntityDrawers extends BaseBlockEntity implements IDrawerGroup /* IProtectable, INameable */
 {
     public static final ModelProperty<IDrawerAttributes> ATTRIBUTES = new ModelProperty<>();
     //public static final ModelProperty<Boolean> ITEM_LOCKED = new ModelProperty<>();
@@ -49,7 +50,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
 
     //private CustomNameData customNameData = new CustomNameData("storagedrawers.container.drawers");
     //private MaterialData materialData = new MaterialData();
-    private UpgradeData upgradeData = new DrawerUpgradeData();
+    private final UpgradeData upgradeData = new DrawerUpgradeData();
 
     //public final ControllerData controllerData = new ControllerData();
 
@@ -59,7 +60,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
     //private UUID owner;
     //private String securityKey;
 
-    private IDrawerAttributesModifiable drawerAttributes;
+    private final IDrawerAttributesModifiable drawerAttributes;
 
     private long lastClickTime;
     private UUID lastClickUUID;
@@ -69,16 +70,16 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
     {
         @Override
         protected void onAttributeChanged () {
-            if (!loading && !TileEntityDrawers.this.drawerAttributes.isItemLocked(LockAttribute.LOCK_POPULATED)) {
-                for (int slot = 0; slot < TileEntityDrawers.this.getGroup().getDrawerCount(); slot++) {
-                    if (TileEntityDrawers.this.emptySlotCanBeCleared(slot)) {
-                        IDrawer drawer = TileEntityDrawers.this.getGroup().getDrawer(slot);
+            if (!loading && !BlockEntityDrawers.this.drawerAttributes.isItemLocked(LockAttribute.LOCK_POPULATED)) {
+                for (int slot = 0; slot < BlockEntityDrawers.this.getGroup().getDrawerCount(); slot++) {
+                    if (BlockEntityDrawers.this.emptySlotCanBeCleared(slot)) {
+                        IDrawer drawer = BlockEntityDrawers.this.getGroup().getDrawer(slot);
                         drawer.setStoredItem(ItemStack.EMPTY);
                     }
                 }
             }
 
-            TileEntityDrawers.this.onAttributeChanged();
+            BlockEntityDrawers.this.onAttributeChanged();
             if (getLevel() != null && !getLevel().isClientSide) {
                 setChanged();
                 markBlockForUpdate();
@@ -93,14 +94,13 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
         }
 
         @Override
-        public boolean canAddUpgrade (@Nonnull ItemStack upgrade) {
+        public boolean canAddUpgrade (@NotNull ItemStack upgrade) {
             if (!super.canAddUpgrade(upgrade))
                 return false;
 
             if (upgrade.getItem() == ModItems.ONE_STACK_UPGRADE.get()) {
                 int lostStackCapacity = upgradeData.getStorageMultiplier() * (getEffectiveDrawerCapacity() - 1);
-                if (!stackCapacityCheck(lostStackCapacity))
-                    return false;
+                return stackCapacityCheck(lostStackCapacity);
             }
 
             return true;
@@ -120,8 +120,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
                     storageMult--;
 
                 int addedStackCapacity = storageMult * getEffectiveDrawerCapacity();
-                if (!stackCapacityCheck(addedStackCapacity))
-                    return false;
+                return stackCapacityCheck(addedStackCapacity);
             }
 
             return true;
@@ -151,8 +150,8 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
         }
     }
 
-    protected TileEntityDrawers (BlockEntityType<?> tileEntityType, BlockPos pos, BlockState state) {
-        super(tileEntityType, pos, state);
+    protected BlockEntityDrawers(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+        super(blockEntityType, pos, state);
 
         drawerAttributes = new DrawerAttributes();
 
@@ -164,8 +163,10 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
         //injectData(controllerData);
     }
 
+    @NotNull
     public abstract IDrawerGroup getGroup ();
 
+    @NotNull
     public IDrawerAttributes getDrawerAttributes () {
         return drawerAttributes;
     }
@@ -200,7 +201,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
     }
 
     protected boolean emptySlotCanBeCleared (int slot) {
-        IDrawer drawer = TileEntityDrawers.this.getGroup().getDrawer(slot);
+        IDrawer drawer = BlockEntityDrawers.this.getGroup().getDrawer(slot);
         return !drawer.isEmpty() && drawer.getStoredItemCount() == 0;
     }
 
@@ -292,16 +293,11 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
         if (type == null)
             return 0;
 
-        switch (type) {
-            case COMBINED:
-                return getCombinedRedstoneLevel();
-            case MAX:
-                return getMaxRedstoneLevel();
-            case MIN:
-                return getMinRedstoneLevel();
-            default:
-                return 0;
-        }
+        return switch (type) {
+            case COMBINED -> getCombinedRedstoneLevel();
+            case MAX -> getMaxRedstoneLevel();
+            case MIN -> getMinRedstoneLevel();
+        };
     }
 
     protected int getCombinedRedstoneLevel () {
@@ -368,7 +364,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
         return (int)Math.ceil(maxRatio * 14);
     }
 
-    @Nonnull
+    @NotNull
     public ItemStack takeItemsFromSlot (int slot, int count) {
         IDrawer drawer = getGroup().getDrawer(slot);
         if (!drawer.isEnabled() || drawer.isEmpty())
@@ -389,7 +385,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
         return stack;
     }
 
-    public int putItemsIntoSlot (int slot, @Nonnull ItemStack stack, int count) {
+    public int putItemsIntoSlot (int slot, @NotNull ItemStack stack, int count) {
         IDrawer drawer = getGroup().getDrawer(slot);
         if (!drawer.isEnabled())
             return 0;
@@ -442,13 +438,16 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
             }
         }
 
-        if (count > 0)
-            StorageDrawers.proxy.updatePlayerInventory(player);
+//        if (count > 0)
+//            StorageDrawers.proxy.updatePlayerInventory(player);
 
         return count;
     }
 
     public int interactPutItemsIntoSlot (int slot, Player player) {
+        if (getLevel() == null)
+            return 0;
+
         int count;
         if (getLevel().getGameTime() - lastClickTime < 10 && player.getUUID().equals(lastClickUUID))
             count = interactPutCurrentInventoryIntoSlot(slot, player);
@@ -555,10 +554,10 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
 
     @OnlyIn(Dist.CLIENT)
     public void clientUpdateCount (final int slot, final int count) {
-        if (!getLevel().isClientSide)
+        if (getLevel() == null || !getLevel().isClientSide)
             return;
 
-        Minecraft.getInstance().tell(() -> TileEntityDrawers.this.clientUpdateCountAsync(slot, count));
+        Minecraft.getInstance().tell(() -> BlockEntityDrawers.this.clientUpdateCountAsync(slot, count));
     }
 
     @OnlyIn(Dist.CLIENT)
@@ -585,14 +584,13 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
         return getGroup().getDrawerCount();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @Deprecated
     public IDrawer getDrawer (int slot) {
         return getGroup().getDrawer(slot);
     }
 
-    @Nonnull
     @Override
     @Deprecated
     public int[] getAccessibleDrawerSlots () {
@@ -622,11 +620,10 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
 
     private final LazyOptional<?> capabilityGroup = LazyOptional.of(this::getGroup);
 
-    @Nonnull
     @Override
-    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> capability, @Nullable Direction facing)
+    @NotNull
+    public <T> LazyOptional<T> getCapability(@NotNull Capability<T> capability, @Nullable Direction facing)
     {
-        IDrawerGroup group = getGroup();
         if (capability == DRAWER_GROUP_CAPABILITY)
             return capabilityGroup.cast();
 
@@ -637,7 +634,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
         return super.getCapability(capability, facing);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public IModelData getModelData () {
         return new ModelDataMap.Builder()

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawers.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.EnumSet;
 import java.util.UUID;
 
-public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawerGroup /* IProtectable, INameable */
+public abstract class BlockEntityDrawers extends BaseBlockEntity implements IDrawerGroup /* IProtectable, INameable */
 {
     public static final ModelProperty<IDrawerAttributes> ATTRIBUTES = new ModelProperty<>();
     //public static final ModelProperty<Boolean> ITEM_LOCKED = new ModelProperty<>();
@@ -70,16 +70,16 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
     {
         @Override
         protected void onAttributeChanged () {
-            if (!loading && !TileEntityDrawers.this.drawerAttributes.isItemLocked(LockAttribute.LOCK_POPULATED)) {
-                for (int slot = 0; slot < TileEntityDrawers.this.getGroup().getDrawerCount(); slot++) {
-                    if (TileEntityDrawers.this.emptySlotCanBeCleared(slot)) {
-                        IDrawer drawer = TileEntityDrawers.this.getGroup().getDrawer(slot);
+            if (!loading && !BlockEntityDrawers.this.drawerAttributes.isItemLocked(LockAttribute.LOCK_POPULATED)) {
+                for (int slot = 0; slot < BlockEntityDrawers.this.getGroup().getDrawerCount(); slot++) {
+                    if (BlockEntityDrawers.this.emptySlotCanBeCleared(slot)) {
+                        IDrawer drawer = BlockEntityDrawers.this.getGroup().getDrawer(slot);
                         drawer.setStoredItem(ItemStack.EMPTY);
                     }
                 }
             }
 
-            TileEntityDrawers.this.onAttributeChanged();
+            BlockEntityDrawers.this.onAttributeChanged();
             if (getLevel() != null && !getLevel().isClientSide) {
                 setChanged();
                 markBlockForUpdate();
@@ -150,7 +150,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
         }
     }
 
-    protected TileEntityDrawers(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+    protected BlockEntityDrawers(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(blockEntityType, pos, state);
 
         drawerAttributes = new DrawerAttributes();
@@ -201,7 +201,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
     }
 
     protected boolean emptySlotCanBeCleared (int slot) {
-        IDrawer drawer = TileEntityDrawers.this.getGroup().getDrawer(slot);
+        IDrawer drawer = BlockEntityDrawers.this.getGroup().getDrawer(slot);
         return !drawer.isEmpty() && drawer.getStoredItemCount() == 0;
     }
 
@@ -557,7 +557,7 @@ public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawe
         if (getLevel() == null || !getLevel().isClientSide)
             return;
 
-        Minecraft.getInstance().tell(() -> TileEntityDrawers.this.clientUpdateCountAsync(slot, count));
+        Minecraft.getInstance().tell(() -> BlockEntityDrawers.this.clientUpdateCountAsync(slot, count));
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawers.java
@@ -618,7 +618,7 @@ public abstract class BlockEntityDrawers extends BaseBlockEntity implements IDra
 
     public static Capability<IDrawerGroup> DRAWER_GROUP_CAPABILITY= CapabilityManager.get(new CapabilityToken<>(){});
 
-    private final LazyOptional<?> capabilityGroup = LazyOptional.of(this::getGroup);
+    private final LazyOptional<IDrawerGroup> capabilityGroup = LazyOptional.of(this::getGroup);
 
     @Override
     @NotNull
@@ -649,5 +649,11 @@ public abstract class BlockEntityDrawers extends BaseBlockEntity implements IDra
             ModelDataManager.requestModelDataRefresh(this);
             Minecraft.getInstance().levelRenderer.setBlocksDirty(worldPosition.getX(), worldPosition.getY(), worldPosition.getZ(), worldPosition.getX(), worldPosition.getY(), worldPosition.getZ());
         });
+    }
+
+    @Override
+    public void invalidateCaps() {
+        super.invalidateCaps();
+        capabilityGroup.invalidate();
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawersComp.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawersComp.java
@@ -129,7 +129,7 @@ public abstract class BlockEntityDrawersComp extends BlockEntityDrawers
             }
         }
 
-        private final LazyOptional<?> capabilityAttributes = LazyOptional.of(BlockEntityDrawersComp.this::getDrawerAttributes);
+        private final LazyOptional<IDrawerAttributes> capabilityAttributes = LazyOptional.of(BlockEntityDrawersComp.this::getDrawerAttributes);
 
         @Override
         @NotNull

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawersComp.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawersComp.java
@@ -27,15 +27,15 @@ import net.minecraftforge.network.PacketDistributor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class TileEntityDrawersComp extends TileEntityDrawers
+public abstract class BlockEntityDrawersComp extends BlockEntityDrawers
 {
     static Capability<IDrawerAttributes> DRAWER_ATTRIBUTES_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    public TileEntityDrawersComp(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+    public BlockEntityDrawersComp(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(blockEntityType, pos, state);
     }
 
-    public static class Slot3 extends TileEntityDrawersComp
+    public static class Slot3 extends BlockEntityDrawersComp
     {
         private final GroupData groupData = new GroupData(3);
 
@@ -78,12 +78,12 @@ public abstract class TileEntityDrawersComp extends TileEntityDrawers
 
         @Override
         protected Level getWorld () {
-            return TileEntityDrawersComp.this.getLevel();
+            return BlockEntityDrawersComp.this.getLevel();
         }
 
         @Override
         public boolean isGroupValid () {
-            return TileEntityDrawersComp.this.isGroupValid();
+            return BlockEntityDrawersComp.this.isGroupValid();
         }
 
         @Override
@@ -129,12 +129,12 @@ public abstract class TileEntityDrawersComp extends TileEntityDrawers
             }
         }
 
-        private final LazyOptional<?> capabilityAttributes = LazyOptional.of(TileEntityDrawersComp.this::getDrawerAttributes);
+        private final LazyOptional<?> capabilityAttributes = LazyOptional.of(BlockEntityDrawersComp.this::getDrawerAttributes);
 
         @Override
         @NotNull
         public <T> LazyOptional<T> getCapability (@NotNull Capability<T> capability, @Nullable Direction facing) {
-            if (capability == TileEntityDrawersComp.DRAWER_ATTRIBUTES_CAPABILITY)
+            if (capability == BlockEntityDrawersComp.DRAWER_ATTRIBUTES_CAPABILITY)
                 return capabilityAttributes.cast();
 
             return super.getCapability(capability, facing);
@@ -174,7 +174,7 @@ public abstract class TileEntityDrawersComp extends TileEntityDrawers
         if (getLevel() == null || !getLevel().isClientSide)
             return;
 
-        Minecraft.getInstance().tell(() -> TileEntityDrawersComp.this.clientUpdateCountAsync(count));
+        Minecraft.getInstance().tell(() -> BlockEntityDrawersComp.this.clientUpdateCountAsync(count));
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawersStandard.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawersStandard.java
@@ -105,7 +105,7 @@ public abstract class BlockEntityDrawersStandard extends BlockEntityDrawers
 
     private class GroupData extends StandardDrawerGroup
     {
-        private final LazyOptional<?> attributesHandler = LazyOptional.of(BlockEntityDrawersStandard.this::getDrawerAttributes);
+        private final LazyOptional<IDrawerAttributes> attributesHandler = LazyOptional.of(BlockEntityDrawersStandard.this::getDrawerAttributes);
 
         public GroupData (int slotCount) {
             super(slotCount);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawersStandard.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawersStandard.java
@@ -17,15 +17,15 @@ import net.minecraftforge.common.util.LazyOptional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class TileEntityDrawersStandard extends TileEntityDrawers
+public abstract class BlockEntityDrawersStandard extends BlockEntityDrawers
 {
     static Capability<IDrawerAttributes> DRAWER_ATTRIBUTES_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    public TileEntityDrawersStandard(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+    public BlockEntityDrawersStandard(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(blockEntityType, pos, state);
     }
 
-    public static class Slot1 extends TileEntityDrawersStandard
+    public static class Slot1 extends BlockEntityDrawersStandard
     {
         private final GroupData groupData = new GroupData(1);
 
@@ -48,7 +48,7 @@ public abstract class TileEntityDrawersStandard extends TileEntityDrawers
         }
     }
 
-    public static class Slot2 extends TileEntityDrawersStandard
+    public static class Slot2 extends BlockEntityDrawersStandard
     {
         private final GroupData groupData = new GroupData(2);
 
@@ -71,7 +71,7 @@ public abstract class TileEntityDrawersStandard extends TileEntityDrawers
         }
     }
 
-    public static class Slot4 extends TileEntityDrawersStandard
+    public static class Slot4 extends BlockEntityDrawersStandard
     {
         private final GroupData groupData = new GroupData(4);
 
@@ -94,7 +94,7 @@ public abstract class TileEntityDrawersStandard extends TileEntityDrawers
         }
     }
 
-    public static TileEntityDrawersStandard createEntity (int slotCount, BlockPos pos, BlockState state) {
+    public static BlockEntityDrawersStandard createEntity (int slotCount, BlockPos pos, BlockState state) {
         return switch (slotCount) {
             case 1 -> new Slot1(pos, state);
             case 2 -> new Slot2(pos, state);
@@ -105,7 +105,7 @@ public abstract class TileEntityDrawersStandard extends TileEntityDrawers
 
     private class GroupData extends StandardDrawerGroup
     {
-        private final LazyOptional<?> attributesHandler = LazyOptional.of(TileEntityDrawersStandard.this::getDrawerAttributes);
+        private final LazyOptional<?> attributesHandler = LazyOptional.of(BlockEntityDrawersStandard.this::getDrawerAttributes);
 
         public GroupData (int slotCount) {
             super(slotCount);
@@ -119,13 +119,13 @@ public abstract class TileEntityDrawersStandard extends TileEntityDrawers
 
         @Override
         public boolean isGroupValid () {
-            return TileEntityDrawersStandard.this.isGroupValid();
+            return BlockEntityDrawersStandard.this.isGroupValid();
         }
 
         @Override
         @NotNull
         public <T> LazyOptional<T> getCapability (@NotNull Capability<T> capability, @Nullable Direction facing) {
-            if (capability == TileEntityDrawersStandard.DRAWER_ATTRIBUTES_CAPABILITY)
+            if (capability == BlockEntityDrawersStandard.DRAWER_ATTRIBUTES_CAPABILITY)
                 return attributesHandler.cast();
 
             return super.getCapability(capability, facing);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawersStandard.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityDrawersStandard.java
@@ -1,6 +1,5 @@
 package com.jaquadro.minecraft.storagedrawers.block.tile;
 
-import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.event.DrawerPopulatedEvent;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
@@ -15,27 +14,20 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.util.LazyOptional;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-public class TileEntityDrawersStandard extends TileEntityDrawers
+public abstract class BlockEntityDrawersStandard extends BlockEntityDrawers
 {
     static Capability<IDrawerAttributes> DRAWER_ATTRIBUTES_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    private static final String[] GUI_IDS = new String[] {
-        null, StorageDrawers.MOD_ID + ":basicDrawers1", StorageDrawers.MOD_ID + ":basicDrawers2", null, StorageDrawers.MOD_ID + ":basicDrawers4"
-    };
-
-    private int capacity = 0;
-
-    public TileEntityDrawersStandard (BlockEntityType<?> tileEntityType, BlockPos pos, BlockState state) {
-        super(tileEntityType, pos, state);
+    public BlockEntityDrawersStandard(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+        super(blockEntityType, pos, state);
     }
 
-    public static class Slot1 extends TileEntityDrawersStandard
+    public static class Slot1 extends BlockEntityDrawersStandard
     {
-        private GroupData groupData = new GroupData(1);
+        private final GroupData groupData = new GroupData(1);
 
         public Slot1 (BlockPos pos, BlockState state) {
             super(ModBlockEntities.STANDARD_DRAWERS_1.get(), pos, state);
@@ -44,6 +36,7 @@ public class TileEntityDrawersStandard extends TileEntityDrawers
         }
 
         @Override
+        @NotNull
         public IDrawerGroup getGroup () {
             return groupData;
         }
@@ -55,9 +48,9 @@ public class TileEntityDrawersStandard extends TileEntityDrawers
         }
     }
 
-    public static class Slot2 extends TileEntityDrawersStandard
+    public static class Slot2 extends BlockEntityDrawersStandard
     {
-        private GroupData groupData = new GroupData(2);
+        private final GroupData groupData = new GroupData(2);
 
         public Slot2 (BlockPos pos, BlockState state) {
             super(ModBlockEntities.STANDARD_DRAWERS_2.get(), pos, state);
@@ -66,6 +59,7 @@ public class TileEntityDrawersStandard extends TileEntityDrawers
         }
 
         @Override
+        @NotNull
         public IDrawerGroup getGroup () {
             return groupData;
         }
@@ -77,9 +71,9 @@ public class TileEntityDrawersStandard extends TileEntityDrawers
         }
     }
 
-    public static class Slot4 extends TileEntityDrawersStandard
+    public static class Slot4 extends BlockEntityDrawersStandard
     {
-        private GroupData groupData = new GroupData(4);
+        private final GroupData groupData = new GroupData(4);
 
         public Slot4 (BlockPos pos, BlockState state) {
             super(ModBlockEntities.STANDARD_DRAWERS_4.get(), pos, state);
@@ -88,6 +82,7 @@ public class TileEntityDrawersStandard extends TileEntityDrawers
         }
 
         @Override
+        @NotNull
         public IDrawerGroup getGroup () {
             return groupData;
         }
@@ -99,33 +94,24 @@ public class TileEntityDrawersStandard extends TileEntityDrawers
         }
     }
 
-    public static TileEntityDrawersStandard createEntity (int slotCount, BlockPos pos, BlockState state) {
-        switch (slotCount) {
-            case 1:
-                return new Slot1(pos, state);
-            case 2:
-                return new Slot2(pos, state);
-            case 4:
-                return new Slot4(pos, state);
-            default:
-                return null;
-        }
-    }
-
-    @Override
-    public IDrawerGroup getGroup () {
-        return null;
+    public static BlockEntityDrawersStandard createEntity (int slotCount, BlockPos pos, BlockState state) {
+        return switch (slotCount) {
+            case 1 -> new Slot1(pos, state);
+            case 2 -> new Slot2(pos, state);
+            case 4 -> new Slot4(pos, state);
+            default -> null;
+        };
     }
 
     private class GroupData extends StandardDrawerGroup
     {
-        private final LazyOptional<?> attributesHandler = LazyOptional.of(TileEntityDrawersStandard.this::getDrawerAttributes);
+        private final LazyOptional<?> attributesHandler = LazyOptional.of(BlockEntityDrawersStandard.this::getDrawerAttributes);
 
         public GroupData (int slotCount) {
             super(slotCount);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         protected DrawerData createDrawer (int slot) {
             return new StandardDrawerData(this, slot);
@@ -133,22 +119,28 @@ public class TileEntityDrawersStandard extends TileEntityDrawers
 
         @Override
         public boolean isGroupValid () {
-            return TileEntityDrawersStandard.this.isGroupValid();
+            return BlockEntityDrawersStandard.this.isGroupValid();
         }
 
-        @Nonnull
         @Override
-        public <T> LazyOptional<T> getCapability (@Nonnull Capability<T> capability, @Nullable Direction facing) {
-            if (capability == TileEntityDrawersStandard.DRAWER_ATTRIBUTES_CAPABILITY)
+        @NotNull
+        public <T> LazyOptional<T> getCapability (@NotNull Capability<T> capability, @Nullable Direction facing) {
+            if (capability == BlockEntityDrawersStandard.DRAWER_ATTRIBUTES_CAPABILITY)
                 return attributesHandler.cast();
 
             return super.getCapability(capability, facing);
+        }
+
+        @Override
+        public void invalidateCaps() {
+            super.invalidateCaps();
+            attributesHandler.invalidate();
         }
     }
 
     private class StandardDrawerData extends StandardDrawerGroup.DrawerData
     {
-        private int slot;
+        private final int slot;
 
         public StandardDrawerData (StandardDrawerGroup group, int slot) {
             super(group);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntitySlave.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntitySlave.java
@@ -101,9 +101,9 @@ public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
     private final DrawerItemHandler itemHandler = new DrawerItemHandler(this);
     private final ItemRepositoryProxy itemRepository = new ItemRepositoryProxy();
 
-    private final LazyOptional<?> capabilityItemHandler = LazyOptional.of(() -> itemHandler);
-    private final LazyOptional<?> capabilityItemRepository = LazyOptional.of(() -> itemRepository);
-    private final LazyOptional<?> capabilityGroup = LazyOptional.of(() -> this);
+    private final LazyOptional<IItemHandler> capabilityItemHandler = LazyOptional.of(() -> itemHandler);
+    private final LazyOptional<IItemRepository> capabilityItemRepository = LazyOptional.of(() -> itemRepository);
+    private final LazyOptional<IDrawerGroup> capabilityGroup = LazyOptional.of(() -> this);
 
     @Override
     @NotNull
@@ -116,6 +116,14 @@ public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
             return capabilityGroup.cast();
 
         return super.getCapability(capability, facing);
+    }
+
+    @Override
+    public void invalidateCaps() {
+        super.invalidateCaps();
+        capabilityItemHandler.invalidate();
+        capabilityItemRepository.invalidate();
+        capabilityGroup.invalidate();
     }
 
     private class ItemRepositoryProxy implements IItemRepository

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntitySlave.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntitySlave.java
@@ -18,24 +18,24 @@ import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.IItemHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.function.Predicate;
 
-public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
+public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
 {
     private static final int[] drawerSlots = new int[]{0};
 
     public final ControllerData controllerData = new ControllerData();
 
-    public TileEntitySlave (BlockEntityType<?> tileEntityType, BlockPos pos, BlockState state) {
-        super(tileEntityType, pos, state);
+    public BlockEntitySlave(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+        super(blockEntityType, pos, state);
 
         injectData(controllerData);
     }
 
-    public TileEntitySlave (BlockPos pos, BlockState state) {
+    public BlockEntitySlave(BlockPos pos, BlockState state) {
         this(ModBlockEntities.CONTROLLER_SLAVE.get(), pos, state);
     }
 
@@ -53,14 +53,13 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
         return controllerData.getCoord();
     }
 
-    public TileEntityController getController () {
+    public BlockEntityController getController () {
         return controllerData.getController(this);
     }
 
-    @Nonnull
     @Override
     public int[] getAccessibleDrawerSlots () {
-        TileEntityController controller = getController();
+        BlockEntityController controller = getController();
         if (controller == null || !controller.isValidSlave(getBlockPos()))
             return drawerSlots;
 
@@ -69,7 +68,7 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
 
     @Override
     public int getDrawerCount () {
-        TileEntityController controller = getController();
+        BlockEntityController controller = getController();
         if (controller == null || !controller.isValidSlave(getBlockPos()))
             return 0;
 
@@ -77,9 +76,9 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public IDrawer getDrawer (int slot) {
-        TileEntityController controller = getController();
+        BlockEntityController controller = getController();
         if (controller == null || !controller.isValidSlave(getBlockPos()))
             return Drawers.DISABLED;
 
@@ -88,7 +87,7 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
 
     @Override
     public void setChanged () {
-        TileEntityController controller = getController();
+        BlockEntityController controller = getController();
         if (controller != null && controller.isValidSlave(getBlockPos()))
             controller.setChanged();
 
@@ -107,8 +106,8 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
     private final LazyOptional<?> capabilityGroup = LazyOptional.of(() -> this);
 
     @Override
-    @Nonnull
-    public <T> LazyOptional<T> getCapability (@Nonnull Capability<T> capability, @Nullable Direction facing) {
+    @NotNull
+    public <T> LazyOptional<T> getCapability (@NotNull Capability<T> capability, @Nullable Direction facing) {
         if (capability == ITEM_HANDLER_CAPABILITY)
             return capabilityItemHandler.cast();
         if (capability == ITEM_REPOSITORY_CAPABILITY)
@@ -121,30 +120,30 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
 
     private class ItemRepositoryProxy implements IItemRepository
     {
-        @Nonnull
+        @NotNull
         @Override
         public NonNullList<ItemRecord> getAllItems () {
-            TileEntityController controller = getController();
+            BlockEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return NonNullList.create();
 
             return controller.getItemRepository().getAllItems();
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public ItemStack insertItem (@Nonnull ItemStack stack, boolean simulate, Predicate<ItemStack> predicate) {
-            TileEntityController controller = getController();
+        public ItemStack insertItem (@NotNull ItemStack stack, boolean simulate, Predicate<ItemStack> predicate) {
+            BlockEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return stack;
 
             return controller.getItemRepository().insertItem(stack, simulate, predicate);
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public ItemStack extractItem (@Nonnull ItemStack stack, int amount, boolean simulate, Predicate<ItemStack> predicate) {
-            TileEntityController controller = getController();
+        public ItemStack extractItem (@NotNull ItemStack stack, int amount, boolean simulate, Predicate<ItemStack> predicate) {
+            BlockEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return ItemStack.EMPTY;
 
@@ -152,8 +151,8 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
         }
 
         @Override
-        public int getStoredItemCount (@Nonnull ItemStack stack, Predicate<ItemStack> predicate) {
-            TileEntityController controller = getController();
+        public int getStoredItemCount (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
+            BlockEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return 0;
 
@@ -161,8 +160,8 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
         }
 
         @Override
-        public int getRemainingItemCapacity (@Nonnull ItemStack stack, Predicate<ItemStack> predicate) {
-            TileEntityController controller = getController();
+        public int getRemainingItemCapacity (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
+            BlockEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return 0;
 
@@ -170,8 +169,8 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
         }
 
         @Override
-        public int getItemCapacity (@Nonnull ItemStack stack, Predicate<ItemStack> predicate) {
-            TileEntityController controller = getController();
+        public int getItemCapacity (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
+            BlockEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return 0;
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntitySlave.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntitySlave.java
@@ -23,19 +23,19 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Predicate;
 
-public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
+public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
 {
     private static final int[] drawerSlots = new int[]{0};
 
     public final ControllerData controllerData = new ControllerData();
 
-    public TileEntitySlave(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+    public BlockEntitySlave(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(blockEntityType, pos, state);
 
         injectData(controllerData);
     }
 
-    public TileEntitySlave(BlockPos pos, BlockState state) {
+    public BlockEntitySlave(BlockPos pos, BlockState state) {
         this(ModBlockEntities.CONTROLLER_SLAVE.get(), pos, state);
     }
 
@@ -53,13 +53,13 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
         return controllerData.getCoord();
     }
 
-    public TileEntityController getController () {
+    public BlockEntityController getController () {
         return controllerData.getController(this);
     }
 
     @Override
     public int[] getAccessibleDrawerSlots () {
-        TileEntityController controller = getController();
+        BlockEntityController controller = getController();
         if (controller == null || !controller.isValidSlave(getBlockPos()))
             return drawerSlots;
 
@@ -68,7 +68,7 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
 
     @Override
     public int getDrawerCount () {
-        TileEntityController controller = getController();
+        BlockEntityController controller = getController();
         if (controller == null || !controller.isValidSlave(getBlockPos()))
             return 0;
 
@@ -78,7 +78,7 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
     @Override
     @NotNull
     public IDrawer getDrawer (int slot) {
-        TileEntityController controller = getController();
+        BlockEntityController controller = getController();
         if (controller == null || !controller.isValidSlave(getBlockPos()))
             return Drawers.DISABLED;
 
@@ -87,7 +87,7 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
 
     @Override
     public void setChanged () {
-        TileEntityController controller = getController();
+        BlockEntityController controller = getController();
         if (controller != null && controller.isValidSlave(getBlockPos()))
             controller.setChanged();
 
@@ -123,7 +123,7 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
         @NotNull
         @Override
         public NonNullList<ItemRecord> getAllItems () {
-            TileEntityController controller = getController();
+            BlockEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return NonNullList.create();
 
@@ -133,7 +133,7 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
         @NotNull
         @Override
         public ItemStack insertItem (@NotNull ItemStack stack, boolean simulate, Predicate<ItemStack> predicate) {
-            TileEntityController controller = getController();
+            BlockEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return stack;
 
@@ -143,7 +143,7 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
         @NotNull
         @Override
         public ItemStack extractItem (@NotNull ItemStack stack, int amount, boolean simulate, Predicate<ItemStack> predicate) {
-            TileEntityController controller = getController();
+            BlockEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return ItemStack.EMPTY;
 
@@ -152,7 +152,7 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
 
         @Override
         public int getStoredItemCount (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
-            TileEntityController controller = getController();
+            BlockEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return 0;
 
@@ -161,7 +161,7 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
 
         @Override
         public int getRemainingItemCapacity (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
-            TileEntityController controller = getController();
+            BlockEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return 0;
 
@@ -170,7 +170,7 @@ public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
 
         @Override
         public int getItemCapacity (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
-            TileEntityController controller = getController();
+            BlockEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return 0;
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/ChamTileEntity.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/ChamTileEntity.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.block.tile;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.BlockEntityDataShim;
+import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.TileDataShim;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
@@ -15,13 +15,13 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BaseBlockEntity extends BlockEntity
+public class ChamTileEntity extends BlockEntity
 {
     private CompoundTag failureSnapshot;
-    private List<BlockEntityDataShim> fixedShims;
-    private List<BlockEntityDataShim> portableShims;
+    private List<TileDataShim> fixedShims;
+    private List<TileDataShim> portableShims;
 
-    public BaseBlockEntity(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+    public ChamTileEntity(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(blockEntityType, pos, state);
     }
 
@@ -33,13 +33,13 @@ public class BaseBlockEntity extends BlockEntity
         return false;
     }
 
-    public void injectData (BlockEntityDataShim shim) {
+    public void injectData (TileDataShim shim) {
         if (fixedShims == null)
             fixedShims = new ArrayList<>();
         fixedShims.add(shim);
     }
 
-    public void injectPortableData (BlockEntityDataShim shim) {
+    public void injectPortableData (TileDataShim shim) {
         if (portableShims == null)
             portableShims = new ArrayList<>();
         portableShims.add(shim);
@@ -92,14 +92,14 @@ public class BaseBlockEntity extends BlockEntity
 
     public void readPortable (CompoundTag tag) {
         if (portableShims != null) {
-            for (BlockEntityDataShim shim : portableShims)
+            for (TileDataShim shim : portableShims)
                 shim.read(tag);
         }
     }
 
     public CompoundTag writePortable (CompoundTag tag) {
         if (portableShims != null) {
-            for (BlockEntityDataShim shim : portableShims)
+            for (TileDataShim shim : portableShims)
                 tag = shim.write(tag);
         }
 
@@ -108,14 +108,14 @@ public class BaseBlockEntity extends BlockEntity
 
     protected void readFixed (CompoundTag tag) {
         if (fixedShims != null) {
-            for (BlockEntityDataShim shim : fixedShims)
+            for (TileDataShim shim : fixedShims)
                 shim.read(tag);
         }
     }
 
     protected CompoundTag writeFixed (CompoundTag tag) {
         if (fixedShims != null) {
-            for (BlockEntityDataShim shim : fixedShims)
+            for (TileDataShim shim : fixedShims)
                 tag = shim.write(tag);
         }
 
@@ -198,8 +198,8 @@ public class BaseBlockEntity extends BlockEntity
     public void invalidateCaps() {
         super.invalidateCaps();
         if (fixedShims != null)
-            fixedShims.forEach(BlockEntityDataShim::invalidateCaps);
+            fixedShims.forEach(TileDataShim::invalidateCaps);
         if (portableShims != null)
-            portableShims.forEach(BlockEntityDataShim::invalidateCaps);
+            portableShims.forEach(TileDataShim::invalidateCaps);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityController.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityController.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.function.Predicate;
 
-public class BlockEntityController extends BaseBlockEntity implements IDrawerGroup
+public class TileEntityController extends ChamTileEntity implements IDrawerGroup
 {
     public static Capability<IDrawerAttributes> DRAWER_ATTRIBUTES_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
@@ -153,12 +153,12 @@ public class BlockEntityController extends BaseBlockEntity implements IDrawerGro
     private long lastClickTime;
     private UUID lastClickUUID;
 
-    protected BlockEntityController(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+    protected TileEntityController(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(blockEntityType, pos, state);
         range = CommonConfig.GENERAL.controllerRange.get();
     }
 
-    public BlockEntityController(BlockPos pos, BlockState state) {
+    public TileEntityController(BlockPos pos, BlockState state) {
         this(ModBlockEntities.CONTROLLER.get(), pos, state);
     }
 
@@ -446,7 +446,7 @@ public class BlockEntityController extends BaseBlockEntity implements IDrawerGro
             return;
         }
 
-        if (blockEntity instanceof BlockEntityController) {
+        if (blockEntity instanceof TileEntityController) {
             if (record.storage == null && record.invStorageSize > 0)
                 return;
 
@@ -455,9 +455,9 @@ public class BlockEntityController extends BaseBlockEntity implements IDrawerGro
 
             record.storage = null;
         }
-        else if (blockEntity instanceof BlockEntitySlave) {
+        else if (blockEntity instanceof TileEntitySlave) {
             if (record.storage == null && record.invStorageSize == 0) {
-                if (((BlockEntitySlave) blockEntity).getController() == this)
+                if (((TileEntitySlave) blockEntity).getController() == this)
                     return;
             }
 
@@ -466,10 +466,10 @@ public class BlockEntityController extends BaseBlockEntity implements IDrawerGro
 
             record.storage = null;
 
-            ((BlockEntitySlave) blockEntity).bindController(getBlockPos());
+            ((TileEntitySlave) blockEntity).bindController(getBlockPos());
         }
-        else if (blockEntity instanceof BlockEntityDrawers) {
-            IDrawerGroup group = ((BlockEntityDrawers) blockEntity).getGroup();
+        else if (blockEntity instanceof TileEntityDrawers) {
+            IDrawerGroup group = ((TileEntityDrawers) blockEntity).getGroup();
             if (record.storage == group)
                 return;
 
@@ -530,7 +530,7 @@ public class BlockEntityController extends BaseBlockEntity implements IDrawerGro
             }
 
             if (block instanceof BlockSlave) {
-                WorldUtils.getBlockEntity(getLevel(), coord, BlockEntitySlave.class);
+                WorldUtils.getBlockEntity(getLevel(), coord, TileEntitySlave.class);
             }
 
             updateRecordInfo(coord, record, getLevel().getBlockEntity(coord));

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.EnumSet;
 import java.util.UUID;
 
-public abstract class BlockEntityDrawers extends BaseBlockEntity implements IDrawerGroup /* IProtectable, INameable */
+public abstract class TileEntityDrawers extends ChamTileEntity implements IDrawerGroup /* IProtectable, INameable */
 {
     public static final ModelProperty<IDrawerAttributes> ATTRIBUTES = new ModelProperty<>();
     //public static final ModelProperty<Boolean> ITEM_LOCKED = new ModelProperty<>();
@@ -70,16 +70,16 @@ public abstract class BlockEntityDrawers extends BaseBlockEntity implements IDra
     {
         @Override
         protected void onAttributeChanged () {
-            if (!loading && !BlockEntityDrawers.this.drawerAttributes.isItemLocked(LockAttribute.LOCK_POPULATED)) {
-                for (int slot = 0; slot < BlockEntityDrawers.this.getGroup().getDrawerCount(); slot++) {
-                    if (BlockEntityDrawers.this.emptySlotCanBeCleared(slot)) {
-                        IDrawer drawer = BlockEntityDrawers.this.getGroup().getDrawer(slot);
+            if (!loading && !TileEntityDrawers.this.drawerAttributes.isItemLocked(LockAttribute.LOCK_POPULATED)) {
+                for (int slot = 0; slot < TileEntityDrawers.this.getGroup().getDrawerCount(); slot++) {
+                    if (TileEntityDrawers.this.emptySlotCanBeCleared(slot)) {
+                        IDrawer drawer = TileEntityDrawers.this.getGroup().getDrawer(slot);
                         drawer.setStoredItem(ItemStack.EMPTY);
                     }
                 }
             }
 
-            BlockEntityDrawers.this.onAttributeChanged();
+            TileEntityDrawers.this.onAttributeChanged();
             if (getLevel() != null && !getLevel().isClientSide) {
                 setChanged();
                 markBlockForUpdate();
@@ -150,7 +150,7 @@ public abstract class BlockEntityDrawers extends BaseBlockEntity implements IDra
         }
     }
 
-    protected BlockEntityDrawers(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+    protected TileEntityDrawers(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(blockEntityType, pos, state);
 
         drawerAttributes = new DrawerAttributes();
@@ -201,7 +201,7 @@ public abstract class BlockEntityDrawers extends BaseBlockEntity implements IDra
     }
 
     protected boolean emptySlotCanBeCleared (int slot) {
-        IDrawer drawer = BlockEntityDrawers.this.getGroup().getDrawer(slot);
+        IDrawer drawer = TileEntityDrawers.this.getGroup().getDrawer(slot);
         return !drawer.isEmpty() && drawer.getStoredItemCount() == 0;
     }
 
@@ -557,7 +557,7 @@ public abstract class BlockEntityDrawers extends BaseBlockEntity implements IDra
         if (getLevel() == null || !getLevel().isClientSide)
             return;
 
-        Minecraft.getInstance().tell(() -> BlockEntityDrawers.this.clientUpdateCountAsync(slot, count));
+        Minecraft.getInstance().tell(() -> TileEntityDrawers.this.clientUpdateCountAsync(slot, count));
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersComp.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersComp.java
@@ -27,15 +27,15 @@ import net.minecraftforge.network.PacketDistributor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class BlockEntityDrawersComp extends BlockEntityDrawers
+public abstract class TileEntityDrawersComp extends TileEntityDrawers
 {
     static Capability<IDrawerAttributes> DRAWER_ATTRIBUTES_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    public BlockEntityDrawersComp(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+    public TileEntityDrawersComp(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(blockEntityType, pos, state);
     }
 
-    public static class Slot3 extends BlockEntityDrawersComp
+    public static class Slot3 extends TileEntityDrawersComp
     {
         private final GroupData groupData = new GroupData(3);
 
@@ -78,12 +78,12 @@ public abstract class BlockEntityDrawersComp extends BlockEntityDrawers
 
         @Override
         protected Level getWorld () {
-            return BlockEntityDrawersComp.this.getLevel();
+            return TileEntityDrawersComp.this.getLevel();
         }
 
         @Override
         public boolean isGroupValid () {
-            return BlockEntityDrawersComp.this.isGroupValid();
+            return TileEntityDrawersComp.this.isGroupValid();
         }
 
         @Override
@@ -129,12 +129,12 @@ public abstract class BlockEntityDrawersComp extends BlockEntityDrawers
             }
         }
 
-        private final LazyOptional<?> capabilityAttributes = LazyOptional.of(BlockEntityDrawersComp.this::getDrawerAttributes);
+        private final LazyOptional<?> capabilityAttributes = LazyOptional.of(TileEntityDrawersComp.this::getDrawerAttributes);
 
         @Override
         @NotNull
         public <T> LazyOptional<T> getCapability (@NotNull Capability<T> capability, @Nullable Direction facing) {
-            if (capability == BlockEntityDrawersComp.DRAWER_ATTRIBUTES_CAPABILITY)
+            if (capability == TileEntityDrawersComp.DRAWER_ATTRIBUTES_CAPABILITY)
                 return capabilityAttributes.cast();
 
             return super.getCapability(capability, facing);
@@ -174,7 +174,7 @@ public abstract class BlockEntityDrawersComp extends BlockEntityDrawers
         if (getLevel() == null || !getLevel().isClientSide)
             return;
 
-        Minecraft.getInstance().tell(() -> BlockEntityDrawersComp.this.clientUpdateCountAsync(count));
+        Minecraft.getInstance().tell(() -> TileEntityDrawersComp.this.clientUpdateCountAsync(count));
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersStandard.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersStandard.java
@@ -17,15 +17,15 @@ import net.minecraftforge.common.util.LazyOptional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class BlockEntityDrawersStandard extends BlockEntityDrawers
+public abstract class TileEntityDrawersStandard extends TileEntityDrawers
 {
     static Capability<IDrawerAttributes> DRAWER_ATTRIBUTES_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    public BlockEntityDrawersStandard(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+    public TileEntityDrawersStandard(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(blockEntityType, pos, state);
     }
 
-    public static class Slot1 extends BlockEntityDrawersStandard
+    public static class Slot1 extends TileEntityDrawersStandard
     {
         private final GroupData groupData = new GroupData(1);
 
@@ -48,7 +48,7 @@ public abstract class BlockEntityDrawersStandard extends BlockEntityDrawers
         }
     }
 
-    public static class Slot2 extends BlockEntityDrawersStandard
+    public static class Slot2 extends TileEntityDrawersStandard
     {
         private final GroupData groupData = new GroupData(2);
 
@@ -71,7 +71,7 @@ public abstract class BlockEntityDrawersStandard extends BlockEntityDrawers
         }
     }
 
-    public static class Slot4 extends BlockEntityDrawersStandard
+    public static class Slot4 extends TileEntityDrawersStandard
     {
         private final GroupData groupData = new GroupData(4);
 
@@ -94,7 +94,7 @@ public abstract class BlockEntityDrawersStandard extends BlockEntityDrawers
         }
     }
 
-    public static BlockEntityDrawersStandard createEntity (int slotCount, BlockPos pos, BlockState state) {
+    public static TileEntityDrawersStandard createEntity (int slotCount, BlockPos pos, BlockState state) {
         return switch (slotCount) {
             case 1 -> new Slot1(pos, state);
             case 2 -> new Slot2(pos, state);
@@ -105,7 +105,7 @@ public abstract class BlockEntityDrawersStandard extends BlockEntityDrawers
 
     private class GroupData extends StandardDrawerGroup
     {
-        private final LazyOptional<?> attributesHandler = LazyOptional.of(BlockEntityDrawersStandard.this::getDrawerAttributes);
+        private final LazyOptional<?> attributesHandler = LazyOptional.of(TileEntityDrawersStandard.this::getDrawerAttributes);
 
         public GroupData (int slotCount) {
             super(slotCount);
@@ -119,13 +119,13 @@ public abstract class BlockEntityDrawersStandard extends BlockEntityDrawers
 
         @Override
         public boolean isGroupValid () {
-            return BlockEntityDrawersStandard.this.isGroupValid();
+            return TileEntityDrawersStandard.this.isGroupValid();
         }
 
         @Override
         @NotNull
         public <T> LazyOptional<T> getCapability (@NotNull Capability<T> capability, @Nullable Direction facing) {
-            if (capability == BlockEntityDrawersStandard.DRAWER_ATTRIBUTES_CAPABILITY)
+            if (capability == TileEntityDrawersStandard.DRAWER_ATTRIBUTES_CAPABILITY)
                 return attributesHandler.cast();
 
             return super.getCapability(capability, facing);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntitySlave.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntitySlave.java
@@ -23,19 +23,19 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Predicate;
 
-public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
+public class TileEntitySlave extends ChamTileEntity implements IDrawerGroup
 {
     private static final int[] drawerSlots = new int[]{0};
 
     public final ControllerData controllerData = new ControllerData();
 
-    public BlockEntitySlave(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
+    public TileEntitySlave(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(blockEntityType, pos, state);
 
         injectData(controllerData);
     }
 
-    public BlockEntitySlave(BlockPos pos, BlockState state) {
+    public TileEntitySlave(BlockPos pos, BlockState state) {
         this(ModBlockEntities.CONTROLLER_SLAVE.get(), pos, state);
     }
 
@@ -53,13 +53,13 @@ public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
         return controllerData.getCoord();
     }
 
-    public BlockEntityController getController () {
+    public TileEntityController getController () {
         return controllerData.getController(this);
     }
 
     @Override
     public int[] getAccessibleDrawerSlots () {
-        BlockEntityController controller = getController();
+        TileEntityController controller = getController();
         if (controller == null || !controller.isValidSlave(getBlockPos()))
             return drawerSlots;
 
@@ -68,7 +68,7 @@ public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
 
     @Override
     public int getDrawerCount () {
-        BlockEntityController controller = getController();
+        TileEntityController controller = getController();
         if (controller == null || !controller.isValidSlave(getBlockPos()))
             return 0;
 
@@ -78,7 +78,7 @@ public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
     @Override
     @NotNull
     public IDrawer getDrawer (int slot) {
-        BlockEntityController controller = getController();
+        TileEntityController controller = getController();
         if (controller == null || !controller.isValidSlave(getBlockPos()))
             return Drawers.DISABLED;
 
@@ -87,7 +87,7 @@ public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
 
     @Override
     public void setChanged () {
-        BlockEntityController controller = getController();
+        TileEntityController controller = getController();
         if (controller != null && controller.isValidSlave(getBlockPos()))
             controller.setChanged();
 
@@ -123,7 +123,7 @@ public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
         @NotNull
         @Override
         public NonNullList<ItemRecord> getAllItems () {
-            BlockEntityController controller = getController();
+            TileEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return NonNullList.create();
 
@@ -133,7 +133,7 @@ public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
         @NotNull
         @Override
         public ItemStack insertItem (@NotNull ItemStack stack, boolean simulate, Predicate<ItemStack> predicate) {
-            BlockEntityController controller = getController();
+            TileEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return stack;
 
@@ -143,7 +143,7 @@ public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
         @NotNull
         @Override
         public ItemStack extractItem (@NotNull ItemStack stack, int amount, boolean simulate, Predicate<ItemStack> predicate) {
-            BlockEntityController controller = getController();
+            TileEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return ItemStack.EMPTY;
 
@@ -152,7 +152,7 @@ public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
 
         @Override
         public int getStoredItemCount (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
-            BlockEntityController controller = getController();
+            TileEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return 0;
 
@@ -161,7 +161,7 @@ public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
 
         @Override
         public int getRemainingItemCapacity (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
-            BlockEntityController controller = getController();
+            TileEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return 0;
 
@@ -170,7 +170,7 @@ public class BlockEntitySlave extends BaseBlockEntity implements IDrawerGroup
 
         @Override
         public int getItemCapacity (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
-            BlockEntityController controller = getController();
+            TileEntityController controller = getController();
             if (controller == null || !controller.isValidSlave(getBlockPos()))
                 return 0;
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/BlockEntityDataShim.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/BlockEntityDataShim.java
@@ -3,7 +3,7 @@ package com.jaquadro.minecraft.storagedrawers.block.tile.tiledata;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraftforge.common.util.INBTSerializable;
 
-public abstract class TileDataShim implements INBTSerializable<CompoundTag>
+public abstract class BlockEntityDataShim implements INBTSerializable<CompoundTag>
 {
     public abstract void read (CompoundTag tag);
 
@@ -19,4 +19,6 @@ public abstract class TileDataShim implements INBTSerializable<CompoundTag>
     public void deserializeNBT (CompoundTag nbt) {
         read(nbt);
     }
+
+    public void invalidateCaps() {}
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/BlockEntityDataShim.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/BlockEntityDataShim.java
@@ -3,7 +3,7 @@ package com.jaquadro.minecraft.storagedrawers.block.tile.tiledata;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraftforge.common.util.INBTSerializable;
 
-public abstract class TileDataShim implements INBTSerializable<CompoundTag>
+public abstract class BlockEntityDataShim implements INBTSerializable<CompoundTag>
 {
     public abstract void read (CompoundTag tag);
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/ControllerData.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/ControllerData.java
@@ -1,12 +1,12 @@
 package com.jaquadro.minecraft.storagedrawers.block.tile.tiledata;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityController;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
-public class ControllerData extends BlockEntityDataShim
+public class ControllerData extends TileDataShim
 {
     private BlockPos controllerCoord;
 
@@ -36,20 +36,20 @@ public class ControllerData extends BlockEntityDataShim
         return controllerCoord;
     }
 
-    public BlockEntityController getController (BlockEntity host) {
+    public TileEntityController getController (BlockEntity host) {
         if (controllerCoord == null)
             return null;
         if (host.getLevel() == null)
             return null;
 
         BlockEntity blockEntity = host.getLevel().getBlockEntity(controllerCoord);
-        if (!(blockEntity instanceof BlockEntityController)) {
+        if (!(blockEntity instanceof TileEntityController)) {
             controllerCoord = null;
             host.setChanged();
             return null;
         }
 
-        return (BlockEntityController)blockEntity;
+        return (TileEntityController)blockEntity;
     }
 
     public boolean bindCoord (BlockPos pos) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/ControllerData.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/ControllerData.java
@@ -1,12 +1,12 @@
 package com.jaquadro.minecraft.storagedrawers.block.tile.tiledata;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityController;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
-public class ControllerData extends TileDataShim
+public class ControllerData extends BlockEntityDataShim
 {
     private BlockPos controllerCoord;
 
@@ -36,20 +36,20 @@ public class ControllerData extends TileDataShim
         return controllerCoord;
     }
 
-    public TileEntityController getController (BlockEntity host) {
+    public BlockEntityController getController (BlockEntity host) {
         if (controllerCoord == null)
             return null;
         if (host.getLevel() == null)
             return null;
 
         BlockEntity blockEntity = host.getLevel().getBlockEntity(controllerCoord);
-        if (!(blockEntity instanceof TileEntityController)) {
+        if (!(blockEntity instanceof BlockEntityController)) {
             controllerCoord = null;
             host.setChanged();
             return null;
         }
 
-        return (TileEntityController)blockEntity;
+        return (BlockEntityController)blockEntity;
     }
 
     public boolean bindCoord (BlockPos pos) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/ControllerData.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/ControllerData.java
@@ -1,12 +1,12 @@
 package com.jaquadro.minecraft.storagedrawers.block.tile.tiledata;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityController;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.core.BlockPos;
 
-public class ControllerData extends TileDataShim
+public class ControllerData extends BlockEntityDataShim
 {
     private BlockPos controllerCoord;
 
@@ -36,18 +36,20 @@ public class ControllerData extends TileDataShim
         return controllerCoord;
     }
 
-    public TileEntityController getController (BlockEntity host) {
+    public BlockEntityController getController (BlockEntity host) {
         if (controllerCoord == null)
             return null;
+        if (host.getLevel() == null)
+            return null;
 
-        BlockEntity te = host.getLevel().getBlockEntity(controllerCoord);
-        if (!(te instanceof TileEntityController)) {
+        BlockEntity blockEntity = host.getLevel().getBlockEntity(controllerCoord);
+        if (!(blockEntity instanceof BlockEntityController)) {
             controllerCoord = null;
             host.setChanged();
             return null;
         }
 
-        return (TileEntityController)te;
+        return (BlockEntityController)blockEntity;
     }
 
     public boolean bindCoord (BlockPos pos) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Stack;
 import java.util.function.Predicate;
 
-public class FractionalDrawerGroup extends BlockEntityDataShim implements IDrawerGroup
+public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
 {
     static Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
     static Capability<IItemRepository> ITEM_REPOSITORY_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
@@ -460,7 +460,7 @@ public class FractionalDrawerGroup extends BlockEntityDataShim implements IDrawe
             CompactingHelper compacting = new CompactingHelper(world);
             Stack<CompactingHelper.Result> resultStack = new Stack<>();
 
-            @NotNull ItemStack lookupTarget = itemPrototype;
+            ItemStack lookupTarget = itemPrototype;
             for (int i = 0; i < slotCount - 1; i++) {
                 CompactingHelper.Result lookup = compacting.findHigherTier(lookupTarget);
                 if (lookup.getStack().isEmpty())
@@ -490,18 +490,19 @@ public class FractionalDrawerGroup extends BlockEntityDataShim implements IDrawe
             lookupTarget = itemPrototype;
             for (; index < slotCount; index++) {
                 CompactingHelper.Result lookup = compacting.findLowerTier(lookupTarget);
-                if (lookup.getStack().isEmpty())
-                    break;
+                ItemStack itemStack = lookup.getStack();
+                if (!itemStack.isEmpty()) {
+                    populateRawSlot(index, itemStack, 1);
+                    group.log("Picked candidate " + itemStack + " with conv=" + lookup.getSize());
 
-                populateRawSlot(index, lookup.getStack(), 1);
-                group.log("Picked candidate " + lookup.getStack().toString() + " with conv=" + lookup.getSize());
-
-                for (int i = 0; i < index; i++) {
-                    convRate[i] *= lookup.getSize();
-                    cachedConvRate[i] = convRate[i];
+                    for (int i = 0; i < index; i++) {
+                        convRate[i] *= lookup.getSize();
+                        cachedConvRate[i] = convRate[i];
+                    }
+                } else {
+                    populateRawSlot(index, ItemStack.EMPTY, 0);
                 }
-
-                lookupTarget = lookup.getStack();
+                lookupTarget = itemStack;
             }
         }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
@@ -36,12 +36,10 @@ public class FractionalDrawerGroup extends BlockEntityDataShim implements IDrawe
     private final FractionalDrawer[] slots;
     private final int[] order;
 
-    private final LazyOptional<IItemHandler> itemHandler;
-    private final LazyOptional<IItemRepository> itemRepository;
+    private final LazyOptional<IItemHandler> itemHandler = LazyOptional.of(() -> new DrawerItemHandler(this));
+    private final LazyOptional<IItemRepository> itemRepository = LazyOptional.of(() -> new DrawerItemRepository(this));
 
     public FractionalDrawerGroup (int slotCount) {
-        itemHandler = LazyOptional.of(() -> new DrawerItemHandler(this));
-        itemRepository = LazyOptional.of(() -> new DrawerItemRepository(this));
 
         storage = new FractionalStorage(this, slotCount);
 
@@ -123,6 +121,13 @@ public class FractionalDrawerGroup extends BlockEntityDataShim implements IDrawe
     protected void onItemChanged () { }
 
     protected void onAmountChanged () { }
+
+    @Override
+    public void invalidateCaps() {
+        super.invalidateCaps();
+        itemHandler.invalidate();
+        itemRepository.invalidate();
+    }
 
     private static class FractionalStorage implements INBTSerializable<CompoundTag>
     {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Stack;
 import java.util.function.Predicate;
 
-public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
+public class FractionalDrawerGroup extends BlockEntityDataShim implements IDrawerGroup
 {
     static Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
     static Capability<IItemRepository> ITEM_REPOSITORY_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
@@ -8,11 +8,11 @@ import com.jaquadro.minecraft.storagedrawers.capabilities.DrawerItemRepository;
 import com.jaquadro.minecraft.storagedrawers.inventory.ItemStackHelper;
 import com.jaquadro.minecraft.storagedrawers.util.CompactingHelper;
 import com.jaquadro.minecraft.storagedrawers.util.ItemStackMatcher;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
-import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
@@ -21,20 +21,20 @@ import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.IItemHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Stack;
 import java.util.function.Predicate;
 
-public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
+public class FractionalDrawerGroup extends BlockEntityDataShim implements IDrawerGroup
 {
     static Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
     static Capability<IItemRepository> ITEM_REPOSITORY_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    private FractionalStorage storage;
-    private FractionalDrawer[] slots;
-    private int[] order;
+    private final FractionalStorage storage;
+    private final FractionalDrawer[] slots;
+    private final int[] order;
 
     private final LazyOptional<IItemHandler> itemHandler;
     private final LazyOptional<IItemRepository> itemRepository;
@@ -63,7 +63,7 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
         return slots.length;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public IFractionalDrawer getDrawer (int slot) {
         if (slot < 0 || slot >= slots.length)
@@ -72,7 +72,6 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
         return slots[slot];
     }
 
-    @Nonnull
     @Override
     public int[] getAccessibleDrawerSlots () {
         return order;
@@ -98,9 +97,9 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
         return tag;
     }
 
-    @Nonnull
     @Override
-    public <T> LazyOptional<T> getCapability (@Nonnull Capability<T> capability, @Nullable Direction facing) {
+    @NotNull
+    public <T> LazyOptional<T> getCapability (@NotNull Capability<T> capability, @Nullable Direction facing) {
         if (capability == ITEM_HANDLER_CAPABILITY)
             return itemHandler.cast();
         if (capability == ITEM_REPOSITORY_CAPABILITY)
@@ -129,17 +128,17 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
     {
         static Capability<IDrawerAttributes> ATTR_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-        private FractionalDrawerGroup group;
-        private int slotCount;
-        private ItemStack[] protoStack;
-        private int[] convRate;
-        private ItemStackMatcher[] matchers;
+        private final FractionalDrawerGroup group;
+        private final int slotCount;
+        private final ItemStack[] protoStack;
+        private final int[] convRate;
+        private final ItemStackMatcher[] matchers;
         private int pooledCount;
 
         private ItemStack cacheKey;
-        private ItemStack[] cachedProtoStack;
-        private int[] cachedConvRate;
-        private ItemStackMatcher[] cachedMatchers;
+        private final ItemStack[] cachedProtoStack;
+        private final int[] cachedConvRate;
+        private final ItemStackMatcher[] cachedMatchers;
 
         IDrawerAttributes attrs;
 
@@ -184,12 +183,12 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
             }
         }
 
-        @Nonnull
+        @NotNull
         public ItemStack getStack (int slot) {
             return protoStack[slot];
         }
 
-        @Nonnull
+        @NotNull
         public ItemStack baseStack () {
             return protoStack[0];
         }
@@ -198,7 +197,7 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
             return convRate[0];
         }
 
-        public IFractionalDrawer setStoredItem (int slot, @Nonnull ItemStack itemPrototype) {
+        public IFractionalDrawer setStoredItem (int slot, @NotNull ItemStack itemPrototype) {
             itemPrototype = ItemStackHelper.getItemPrototype(itemPrototype);
             if (itemPrototype.isEmpty()) {
                 reset();
@@ -305,7 +304,7 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
             return baseStack().getItem().getItemStackLimit(baseStack()) * group.getStackCapacity() * (baseRate() / convRate[slot]);
         }
 
-        public int getMaxCapacity (int slot, @Nonnull ItemStack itemPrototype) {
+        public int getMaxCapacity (int slot, @NotNull ItemStack itemPrototype) {
             if (attrs.isUnlimitedStorage() || attrs.isUnlimitedVending()) {
                 if (convRate[slot] == 0)
                     return Integer.MAX_VALUE;
@@ -325,7 +324,7 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
             return 0;
         }
 
-        public int getAcceptingMaxCapacity (int slot, @Nonnull ItemStack itemPrototype) {
+        public int getAcceptingMaxCapacity (int slot, @NotNull ItemStack itemPrototype) {
             if (attrs.isVoid())
                 return Integer.MAX_VALUE;
 
@@ -369,7 +368,7 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
             return !protoStack[slot].isEmpty();
         }
 
-        public boolean canItemBeStored (int slot, @Nonnull ItemStack itemPrototype, Predicate<ItemStack> predicate) {
+        public boolean canItemBeStored (int slot, @NotNull ItemStack itemPrototype, Predicate<ItemStack> predicate) {
             if (protoStack[slot].isEmpty() && protoStack[0].isEmpty() && !attrs.isItemLocked(LockAttribute.LOCK_EMPTY))
                 return true;
 
@@ -378,7 +377,7 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
             return predicate.test(protoStack[slot]);
         }
 
-        public boolean canItemBeExtracted (int slot, @Nonnull ItemStack itemPrototype, Predicate<ItemStack> predicate) {
+        public boolean canItemBeExtracted (int slot, @NotNull ItemStack itemPrototype, Predicate<ItemStack> predicate) {
             if (protoStack[slot].isEmpty())
                 return false;
 
@@ -431,7 +430,7 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
             }
         }
 
-        private void populateSlots (@Nonnull ItemStack itemPrototype) {
+        private void populateSlots (@NotNull ItemStack itemPrototype) {
             Level world = group.getWorld();
             if (world == null) {
                 protoStack[0] = itemPrototype;
@@ -456,7 +455,7 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
             CompactingHelper compacting = new CompactingHelper(world);
             Stack<CompactingHelper.Result> resultStack = new Stack<>();
 
-            @Nonnull ItemStack lookupTarget = itemPrototype;
+            @NotNull ItemStack lookupTarget = itemPrototype;
             for (int i = 0; i < slotCount - 1; i++) {
                 CompactingHelper.Result lookup = compacting.findHigherTier(lookupTarget);
                 if (lookup.getStack().isEmpty())
@@ -501,7 +500,7 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
             }
         }
 
-        private void populateRawSlot (int slot, @Nonnull ItemStack itemPrototype, int rate) {
+        private void populateRawSlot (int slot, @NotNull ItemStack itemPrototype, int rate) {
             protoStack[slot] = itemPrototype;
             convRate[slot] = rate;
             matchers[slot] = new ItemStackMatcher(protoStack[slot]);
@@ -621,25 +620,26 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
         }
     }
 
-    private static class FractionalDrawer implements IFractionalDrawer
-    {
-        private FractionalStorage storage;
-        private int slot;
+    private static class FractionalDrawer implements IFractionalDrawer {
+        private final FractionalStorage storage;
+        private final int slot;
 
-        public FractionalDrawer (FractionalStorage storage, int slot) {
+        private FractionalDrawer(
+                FractionalStorage storage,
+                int slot) {
             this.storage = storage;
             this.slot = slot;
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public ItemStack getStoredItemPrototype () {
+        public ItemStack getStoredItemPrototype() {
             return storage.getStack(slot);
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public IDrawer setStoredItem (@Nonnull ItemStack itemPrototype) {
+        public IDrawer setStoredItem(@NotNull ItemStack itemPrototype) {
             if (ItemStackHelper.isStackEncoded(itemPrototype))
                 itemPrototype = ItemStackHelper.decodeItemStackPrototype(itemPrototype);
 
@@ -647,77 +647,77 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
         }
 
         @Override
-        public int getStoredItemCount () {
+        public int getStoredItemCount() {
             return storage.getStoredCount(slot);
         }
 
         @Override
-        public void setStoredItemCount (int amount) {
+        public void setStoredItemCount(int amount) {
             storage.setStoredItemCount(slot, amount);
         }
 
         @Override
-        public int adjustStoredItemCount (int amount) {
+        public int adjustStoredItemCount(int amount) {
             return storage.adjustStoredItemCount(slot, amount);
         }
 
         @Override
-        public int getMaxCapacity () {
+        public int getMaxCapacity() {
             return storage.getMaxCapacity(slot);
         }
 
         @Override
-        public int getMaxCapacity (@Nonnull ItemStack itemPrototype) {
+        public int getMaxCapacity(@NotNull ItemStack itemPrototype) {
             return storage.getMaxCapacity(slot, itemPrototype);
         }
 
         @Override
-        public int getAcceptingMaxCapacity (@Nonnull ItemStack itemPrototype) {
+        public int getAcceptingMaxCapacity(@NotNull ItemStack itemPrototype) {
             return storage.getAcceptingMaxCapacity(slot, itemPrototype);
         }
 
         @Override
-        public int getRemainingCapacity () {
+        public int getRemainingCapacity() {
             return storage.getRemainingCapacity(slot);
         }
 
         @Override
-        public int getAcceptingRemainingCapacity () {
+        public int getAcceptingRemainingCapacity() {
             return storage.getAcceptingRemainingCapacity(slot);
         }
 
         @Override
-        public boolean canItemBeStored (@Nonnull ItemStack itemPrototype, Predicate<ItemStack> matchPredicate) {
+        public boolean canItemBeStored(@NotNull ItemStack itemPrototype, Predicate<ItemStack> matchPredicate) {
             return storage.canItemBeStored(slot, itemPrototype, matchPredicate);
         }
 
         @Override
-        public boolean canItemBeExtracted (@Nonnull ItemStack itemPrototype, Predicate<ItemStack> matchPredicate) {
+        public boolean canItemBeExtracted(@NotNull ItemStack itemPrototype, Predicate<ItemStack> matchPredicate) {
             return storage.canItemBeExtracted(slot, itemPrototype, matchPredicate);
         }
 
         @Override
-        public boolean isEmpty () {
+        public boolean isEmpty() {
             return storage.isEmpty(slot);
         }
 
         @Override
-        public boolean isEnabled () {
+        public boolean isEnabled() {
             return storage.isEnabled(slot);
         }
 
         @Override
-        public int getConversionRate () {
+        public int getConversionRate() {
             return storage.getConversionRate(slot);
         }
 
         @Override
-        public int getStoredItemRemainder () {
+        public int getStoredItemRemainder() {
             return storage.getStoredItemRemainder(slot);
         }
 
         @Override
-        public boolean isSmallestUnit () {
+        public boolean isSmallestUnit() {
             return storage.isSmallestUnit(slot);
         }
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/StandardDrawerGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/StandardDrawerGroup.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Predicate;
 
-public abstract class StandardDrawerGroup extends TileDataShim implements IDrawerGroup
+public abstract class StandardDrawerGroup extends BlockEntityDataShim implements IDrawerGroup
 {
     public static Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
     public static Capability<IItemRepository> ITEM_REPOSITORY_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/StandardDrawerGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/StandardDrawerGroup.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Predicate;
 
-public abstract class StandardDrawerGroup extends BlockEntityDataShim implements IDrawerGroup
+public abstract class StandardDrawerGroup extends TileDataShim implements IDrawerGroup
 {
     public static Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
     public static Capability<IItemRepository> ITEM_REPOSITORY_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/TileDataShim.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/TileDataShim.java
@@ -3,7 +3,7 @@ package com.jaquadro.minecraft.storagedrawers.block.tile.tiledata;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraftforge.common.util.INBTSerializable;
 
-public abstract class BlockEntityDataShim implements INBTSerializable<CompoundTag>
+public abstract class TileDataShim implements INBTSerializable<CompoundTag>
 {
     public abstract void read (CompoundTag tag);
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/UpgradeData.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/UpgradeData.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 
-public class UpgradeData extends BlockEntityDataShim
+public class UpgradeData extends TileDataShim
 {
     protected final ItemStack[] upgrades;
     private int storageMultiplier;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/UpgradeData.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/UpgradeData.java
@@ -3,17 +3,21 @@ package com.jaquadro.minecraft.storagedrawers.block.tile.tiledata;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributesModifiable;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
 import com.jaquadro.minecraft.storagedrawers.core.ModItems;
-import com.jaquadro.minecraft.storagedrawers.item.*;
+import com.jaquadro.minecraft.storagedrawers.item.EnumUpgradeRedstone;
+import com.jaquadro.minecraft.storagedrawers.item.ItemUpgrade;
+import com.jaquadro.minecraft.storagedrawers.item.ItemUpgradeRedstone;
+import com.jaquadro.minecraft.storagedrawers.item.ItemUpgradeStorage;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.util.Mth;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.Tag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.util.Mth;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
+import java.util.Arrays;
 
-public class UpgradeData extends TileDataShim
+public class UpgradeData extends BlockEntityDataShim
 {
     protected final ItemStack[] upgrades;
     private int storageMultiplier;
@@ -32,8 +36,7 @@ public class UpgradeData extends TileDataShim
 
     public UpgradeData (int slotCount) {
         upgrades = new ItemStack[slotCount];
-        for (int i = 0; i < upgrades.length; i++)
-            upgrades[i] = ItemStack.EMPTY;
+        Arrays.fill(upgrades, ItemStack.EMPTY);
 
         syncStorageMultiplier();
     }
@@ -47,7 +50,7 @@ public class UpgradeData extends TileDataShim
         return upgrades.length;
     }
 
-    @Nonnull
+    @NotNull
     public ItemStack getUpgrade (int slot) {
         slot = Mth.clamp(slot, 0, upgrades.length - 1);
         return upgrades[slot];
@@ -57,7 +60,7 @@ public class UpgradeData extends TileDataShim
         return getNextUpgradeSlot() != -1;
     }
 
-    public boolean addUpgrade (@Nonnull ItemStack upgrade) {
+    public boolean addUpgrade (@NotNull ItemStack upgrade) {
         int slot = getNextUpgradeSlot();
         if (slot == -1)
             return false;
@@ -66,7 +69,7 @@ public class UpgradeData extends TileDataShim
         return true;
     }
 
-    public boolean setUpgrade (int slot, @Nonnull ItemStack upgrade) {
+    public boolean setUpgrade (int slot, @NotNull ItemStack upgrade) {
         slot = Mth.clamp(slot, 0, upgrades.length - 1);
 
         if (!upgrade.isEmpty()) {
@@ -95,13 +98,12 @@ public class UpgradeData extends TileDataShim
         return true;
     }
 
-    public boolean canAddUpgrade (@Nonnull ItemStack upgrade) {
+    public boolean canAddUpgrade (@NotNull ItemStack upgrade) {
         if (upgrade.isEmpty())
             return false;
-        if (!(upgrade.getItem() instanceof ItemUpgrade))
+        if (!(upgrade.getItem() instanceof ItemUpgrade candidate))
             return false;
 
-        ItemUpgrade candidate = (ItemUpgrade)upgrade.getItem();
         if (candidate.getAllowMultiple())
             return true;
 
@@ -109,10 +111,9 @@ public class UpgradeData extends TileDataShim
             if (stack.isEmpty())
                 continue;
 
-            if (!(stack.getItem() instanceof ItemUpgrade))
+            if (!(stack.getItem() instanceof ItemUpgrade reference))
                 continue;
 
-            ItemUpgrade reference = (ItemUpgrade)stack.getItem();
             if (candidate.getUpgradeGroup() == reference.getUpgradeGroup())
                 return false;
         }
@@ -229,8 +230,7 @@ public class UpgradeData extends TileDataShim
 
     @Override
     public void read (CompoundTag tag) {
-        for (int i = 0; i < upgrades.length; i++)
-            upgrades[i] = ItemStack.EMPTY;
+        Arrays.fill(upgrades, ItemStack.EMPTY);
 
         if (!tag.contains("Upgrades"))
             return;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/UpgradeData.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/UpgradeData.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 
-public class UpgradeData extends TileDataShim
+public class UpgradeData extends BlockEntityDataShim
 {
     protected final ItemStack[] upgrades;
     private int storageMultiplier;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/capabilities/BasicDrawerAttributes.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/capabilities/BasicDrawerAttributes.java
@@ -1,6 +1,5 @@
 package com.jaquadro.minecraft.storagedrawers.capabilities;
 
-import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributesModifiable;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
 import net.minecraft.nbt.CompoundTag;
@@ -8,7 +7,7 @@ import net.minecraftforge.common.util.INBTSerializable;
 
 import java.util.EnumSet;
 
-public class BasicDrawerAttributes implements IDrawerAttributes, IDrawerAttributesModifiable, INBTSerializable<CompoundTag>
+public class BasicDrawerAttributes implements IDrawerAttributesModifiable, INBTSerializable<CompoundTag>
 {
     private EnumSet<LockAttribute> itemLock = EnumSet.noneOf(LockAttribute.class);
     private boolean isConcealed;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/capabilities/DrawerItemHandler.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/capabilities/DrawerItemHandler.java
@@ -1,21 +1,20 @@
 package com.jaquadro.minecraft.storagedrawers.capabilities;
 
 import com.jaquadro.minecraft.storagedrawers.api.capabilities.IItemRepository;
-import com.jaquadro.minecraft.storagedrawers.api.storage.*;
-import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.items.IItemHandler;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class DrawerItemHandler implements IItemHandler
 {
     public static Capability<IItemRepository> ITEM_REPOSITORY_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
-    private IDrawerGroup group;
+    private final IDrawerGroup group;
 
     public DrawerItemHandler (IDrawerGroup group) {
         this.group = group;
@@ -29,7 +28,7 @@ public class DrawerItemHandler implements IItemHandler
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public ItemStack getStackInSlot (int slot) {
         if (!group.isGroupValid())
             return ItemStack.EMPTY;
@@ -51,8 +50,8 @@ public class DrawerItemHandler implements IItemHandler
     }
 
     @Override
-    @Nonnull
-    public ItemStack insertItem (int slot, @Nonnull ItemStack stack, boolean simulate) {
+    @NotNull
+    public ItemStack insertItem (int slot, @NotNull ItemStack stack, boolean simulate) {
         if (!group.isGroupValid())
             return stack;
 
@@ -82,8 +81,8 @@ public class DrawerItemHandler implements IItemHandler
         return insertItemInternal(orderedSlot, stack, simulate);
     }
 
-    @Nonnull
-    private ItemStack insertItemFullScan (@Nonnull ItemStack stack, boolean simulate) {
+    @NotNull
+    private ItemStack insertItemFullScan (@NotNull ItemStack stack, boolean simulate) {
         IItemRepository itemRepo = group.getCapability(ITEM_REPOSITORY_CAPABILITY, null).orElse(null);
         if (itemRepo != null)
             return itemRepo.insertItem(stack, simulate);
@@ -97,8 +96,8 @@ public class DrawerItemHandler implements IItemHandler
         return stack;
     }
 
-    @Nonnull
-    private ItemStack insertItemInternal (int slot, @Nonnull ItemStack stack, boolean simulate) {
+    @NotNull
+    private ItemStack insertItemInternal (int slot, @NotNull ItemStack stack, boolean simulate) {
         IDrawer drawer = group.getDrawer(slot);
         if (!drawer.canItemBeStored(stack))
             return stack;
@@ -120,7 +119,7 @@ public class DrawerItemHandler implements IItemHandler
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public ItemStack extractItem (int slot, int amount, boolean simulate) {
         if (!group.isGroupValid())
             return ItemStack.EMPTY;
@@ -135,7 +134,7 @@ public class DrawerItemHandler implements IItemHandler
         if (!drawer.isEnabled() || drawer.isEmpty() || drawer.getStoredItemCount() == 0)
             return ItemStack.EMPTY;
 
-        @Nonnull ItemStack prototype = drawer.getStoredItemPrototype();
+        @NotNull ItemStack prototype = drawer.getStoredItemPrototype();
         int remaining = (simulate)
             ? Math.max(amount - drawer.getStoredItemCount(), 0)
             : drawer.adjustStoredItemCount(-amount);
@@ -165,7 +164,7 @@ public class DrawerItemHandler implements IItemHandler
 
     @Override
     // TODO: Implement proper
-    public boolean isItemValid (int slot, @Nonnull ItemStack stack) {
+    public boolean isItemValid (int slot, @NotNull ItemStack stack) {
         return true;
     }
 
@@ -173,7 +172,7 @@ public class DrawerItemHandler implements IItemHandler
         return slot == 0;
     }
 
-    private ItemStack stackResult (@Nonnull ItemStack stack, int amount) {
+    private ItemStack stackResult (@NotNull ItemStack stack, int amount) {
         ItemStack result = stack.copy();
         result.setCount(amount);
         return result;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/capabilities/DrawerItemRepository.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/capabilities/DrawerItemRepository.java
@@ -3,14 +3,11 @@ package com.jaquadro.minecraft.storagedrawers.capabilities;
 import com.jaquadro.minecraft.storagedrawers.api.capabilities.IItemRepository;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.function.Predicate;
-
-import com.jaquadro.minecraft.storagedrawers.api.capabilities.IItemRepository.DefaultPredicate;
-import com.jaquadro.minecraft.storagedrawers.api.capabilities.IItemRepository.ItemRecord;
 
 public class DrawerItemRepository implements IItemRepository
 {
@@ -20,7 +17,7 @@ public class DrawerItemRepository implements IItemRepository
         this.group = group;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public NonNullList<ItemRecord> getAllItems () {
         NonNullList<ItemRecord> records = NonNullList.create();
@@ -39,9 +36,9 @@ public class DrawerItemRepository implements IItemRepository
         return records;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack insertItem (@Nonnull ItemStack stack, boolean simulate, Predicate<ItemStack> predicate) {
+    public ItemStack insertItem (@NotNull ItemStack stack, boolean simulate, Predicate<ItemStack> predicate) {
         int amount = stack.getCount();
 
         for (int slot : group.getAccessibleDrawerSlots()) {
@@ -66,9 +63,9 @@ public class DrawerItemRepository implements IItemRepository
         return stackResult(stack, amount);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack extractItem (@Nonnull ItemStack stack, int amount, boolean simulate, Predicate<ItemStack> predicate) {
+    public ItemStack extractItem (@NotNull ItemStack stack, int amount, boolean simulate, Predicate<ItemStack> predicate) {
         int remaining = amount;
 
         for (int slot : group.getAccessibleDrawerSlots()) {
@@ -92,7 +89,7 @@ public class DrawerItemRepository implements IItemRepository
     }
 
     @Override
-    public int getStoredItemCount (@Nonnull ItemStack stack, Predicate<ItemStack> predicate) {
+    public int getStoredItemCount (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
         long count = 0;
         for (int slot : group.getAccessibleDrawerSlots()) {
             IDrawer drawer = group.getDrawer(slot);
@@ -108,7 +105,7 @@ public class DrawerItemRepository implements IItemRepository
     }
 
     @Override
-    public int getRemainingItemCapacity (@Nonnull ItemStack stack, Predicate<ItemStack> predicate) {
+    public int getRemainingItemCapacity (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
         long remainder = 0;
         for (int slot : group.getAccessibleDrawerSlots()) {
             IDrawer drawer = group.getDrawer(slot);
@@ -124,7 +121,7 @@ public class DrawerItemRepository implements IItemRepository
     }
 
     @Override
-    public int getItemCapacity (@Nonnull ItemStack stack, Predicate<ItemStack> predicate) {
+    public int getItemCapacity (@NotNull ItemStack stack, Predicate<ItemStack> predicate) {
         long capacity = 0;
         for (int slot : group.getAccessibleDrawerSlots()) {
             IDrawer drawer = group.getDrawer(slot);
@@ -139,29 +136,21 @@ public class DrawerItemRepository implements IItemRepository
         return (int)capacity;
     }
 
-    protected boolean testPredicateInsert (IDrawer drawer, @Nonnull ItemStack stack, Predicate<ItemStack> predicate) {
-        if (predicate instanceof DefaultPredicate) {
-            if (!drawer.canItemBeStored(stack) && !predicate.test(drawer.getStoredItemPrototype()))
-                return false;
-        }
-        else if (!drawer.canItemBeStored(stack, predicate))
-            return false;
-
-        return true;
+    protected boolean testPredicateInsert (IDrawer drawer, @NotNull ItemStack stack, Predicate<ItemStack> predicate) {
+        if (predicate instanceof DefaultPredicate)
+            return drawer.canItemBeStored(stack) || predicate.test(drawer.getStoredItemPrototype());
+        else
+            return drawer.canItemBeStored(stack, predicate);
     }
 
-    protected boolean testPredicateExtract (IDrawer drawer, @Nonnull ItemStack stack, Predicate<ItemStack> predicate) {
-        if (predicate instanceof DefaultPredicate) {
-            if (!drawer.canItemBeExtracted(stack) && !predicate.test(drawer.getStoredItemPrototype()))
-                return false;
-        }
-        else if (!drawer.canItemBeStored(stack, predicate))
-            return false;
-
-        return true;
+    protected boolean testPredicateExtract (IDrawer drawer, @NotNull ItemStack stack, Predicate<ItemStack> predicate) {
+        if (predicate instanceof DefaultPredicate)
+            return drawer.canItemBeExtracted(stack) || predicate.test(drawer.getStoredItemPrototype());
+        else
+            return drawer.canItemBeStored(stack, predicate);
     }
 
-    protected ItemStack stackResult (@Nonnull ItemStack stack, int amount) {
+    protected ItemStack stackResult (@NotNull ItemStack stack, int amount) {
         ItemStack result = stack.copy();
         result.setCount(amount);
         return result;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientModBusSubscriber.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientModBusSubscriber.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.client;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.client.renderer.TileEntityDrawersRenderer;
+import com.jaquadro.minecraft.storagedrawers.client.renderer.BlockEntityDrawersRenderer;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlockEntities;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
@@ -35,6 +35,6 @@ public class ClientModBusSubscriber {
 
     @SubscribeEvent
     public static void registerEntityRenderers(RegisterRenderers event) {
-        ModBlockEntities.getBlockEntityTypesWithRenderers().forEach(ro -> event.registerBlockEntityRenderer(ro.get(), TileEntityDrawersRenderer::new));
+        ModBlockEntities.getBlockEntityTypesWithRenderers().forEach(ro -> event.registerBlockEntityRenderer(ro.get(), BlockEntityDrawersRenderer::new));
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientModBusSubscriber.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientModBusSubscriber.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.client;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.client.renderer.BlockEntityDrawersRenderer;
+import com.jaquadro.minecraft.storagedrawers.client.renderer.TileEntityDrawersRenderer;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlockEntities;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
@@ -35,6 +35,6 @@ public class ClientModBusSubscriber {
 
     @SubscribeEvent
     public static void registerEntityRenderers(RegisterRenderers event) {
-        ModBlockEntities.getBlockEntityTypesWithRenderers().forEach(ro -> event.registerBlockEntityRenderer(ro.get(), BlockEntityDrawersRenderer::new));
+        ModBlockEntities.getBlockEntityTypesWithRenderers().forEach(ro -> event.registerBlockEntityRenderer(ro.get(), TileEntityDrawersRenderer::new));
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientModBusSubscriber.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/ClientModBusSubscriber.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.client;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.client.renderer.TileEntityDrawersRenderer;
+import com.jaquadro.minecraft.storagedrawers.client.renderer.BlockEntityDrawersRenderer;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlockEntities;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
@@ -16,7 +16,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
 @Mod.EventBusSubscriber(modid = StorageDrawers.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
-public class ClientEventBusSubscriber {
+public class ClientModBusSubscriber {
     @SubscribeEvent
     public static void clientSetup(FMLClientSetupEvent event) {
         ModBlocks.getDrawers().forEach(blockDrawers -> ItemBlockRenderTypes.setRenderLayer(blockDrawers, RenderType.cutoutMipped()));
@@ -35,6 +35,6 @@ public class ClientEventBusSubscriber {
 
     @SubscribeEvent
     public static void registerEntityRenderers(RegisterRenderers event) {
-        ModBlockEntities.getBlockEntityTypesWithRenderers().forEach(ro -> event.registerBlockEntityRenderer(ro.get(), TileEntityDrawersRenderer::new));
+        ModBlockEntities.getBlockEntityTypesWithRenderers().forEach(ro -> event.registerBlockEntityRenderer(ro.get(), BlockEntityDrawersRenderer::new));
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
@@ -6,7 +6,7 @@ import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
 import com.jaquadro.minecraft.storagedrawers.block.BlockCompDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
 import com.mojang.datafixers.util.Either;
 import com.mojang.math.Vector3f;
@@ -35,9 +35,9 @@ import net.minecraftforge.client.model.data.IModelData;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -301,7 +301,8 @@ public final class BasicDrawerModel
         }
 
         @Override
-        public List<BakedQuad> getQuads (@Nullable BlockState state, @Nullable Direction side, Random rand) {
+        @NotNull
+        public List<BakedQuad> getQuads (@Nullable BlockState state, @Nullable Direction side, @NotNull Random rand) {
             List<BakedQuad> quads = Lists.newArrayList();
             quads.addAll(mainModel.getQuads(state, side, rand));
             for (BakedModel model : models)
@@ -330,11 +331,13 @@ public final class BasicDrawerModel
         }
 
         @Override
+        @NotNull
         public TextureAtlasSprite getParticleIcon () {
             return mainModel.getParticleIcon();
         }
 
         @Override
+        @NotNull
         public ItemOverrides getOverrides () {
             return mainModel.getOverrides();
         }
@@ -384,14 +387,14 @@ public final class BasicDrawerModel
             return mainModel.usesBlockLight();
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public List<BakedQuad> getQuads (@Nullable BlockState state, @Nullable Direction side, @Nonnull Random rand, @Nonnull IModelData extraData) {
+        public List<BakedQuad> getQuads (@Nullable BlockState state, @Nullable Direction side, @NotNull Random rand, @NotNull IModelData extraData) {
             List<BakedQuad> quads = Lists.newArrayList();
             quads.addAll(mainModel.getQuads(state, side, rand, extraData));
 
-            if (state != null && extraData.hasProperty(TileEntityDrawers.ATTRIBUTES)) {
-                IDrawerAttributes attr = extraData.getData(TileEntityDrawers.ATTRIBUTES);
+            if (state != null && extraData.hasProperty(BlockEntityDrawers.ATTRIBUTES)) {
+                IDrawerAttributes attr = extraData.getData(BlockEntityDrawers.ATTRIBUTES);
                 Direction dir = state.getValue(BlockDrawers.FACING);
 
                 if (attr.isItemLocked(LockAttribute.LOCK_EMPTY) || attr.isItemLocked(LockAttribute.LOCK_POPULATED))
@@ -435,11 +438,13 @@ public final class BasicDrawerModel
         }
 
         @Override
+        @NotNull
         public TextureAtlasSprite getParticleIcon () {
             return mainModel.getParticleIcon();
         }
 
         @Override
+        @NotNull
         public ItemOverrides getOverrides () {
             return mainModel.getOverrides();
         }
@@ -506,7 +511,7 @@ public final class BasicDrawerModel
         }
 
         @Override
-        public IBakedModel handleItemState (IBakedModel parent, @Nonnull ItemStack stack, World world, EntityLivingBase entity) {
+        public IBakedModel handleItemState (IBakedModel parent, @NotNull ItemStack stack, World world, EntityLivingBase entity) {
             if (stack.isEmpty())
                 return parent;
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
@@ -6,7 +6,7 @@ import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
 import com.jaquadro.minecraft.storagedrawers.block.BlockCompDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
 import com.mojang.datafixers.util.Either;
 import com.mojang.math.Vector3f;
@@ -393,8 +393,8 @@ public final class BasicDrawerModel
             List<BakedQuad> quads = Lists.newArrayList();
             quads.addAll(mainModel.getQuads(state, side, rand, extraData));
 
-            if (state != null && extraData.hasProperty(BlockEntityDrawers.ATTRIBUTES)) {
-                IDrawerAttributes attr = extraData.getData(BlockEntityDrawers.ATTRIBUTES);
+            if (state != null && extraData.hasProperty(TileEntityDrawers.ATTRIBUTES)) {
+                IDrawerAttributes attr = extraData.getData(TileEntityDrawers.ATTRIBUTES);
                 Direction dir = state.getValue(BlockDrawers.FACING);
 
                 if (attr.isItemLocked(LockAttribute.LOCK_EMPTY) || attr.isItemLocked(LockAttribute.LOCK_POPULATED))

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
@@ -6,7 +6,7 @@ import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
 import com.jaquadro.minecraft.storagedrawers.block.BlockCompDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
 import com.mojang.datafixers.util.Either;
 import com.mojang.math.Vector3f;
@@ -393,8 +393,8 @@ public final class BasicDrawerModel
             List<BakedQuad> quads = Lists.newArrayList();
             quads.addAll(mainModel.getQuads(state, side, rand, extraData));
 
-            if (state != null && extraData.hasProperty(TileEntityDrawers.ATTRIBUTES)) {
-                IDrawerAttributes attr = extraData.getData(TileEntityDrawers.ATTRIBUTES);
+            if (state != null && extraData.hasProperty(BlockEntityDrawers.ATTRIBUTES)) {
+                IDrawerAttributes attr = extraData.getData(BlockEntityDrawers.ATTRIBUTES);
                 Direction dir = state.getValue(BlockDrawers.FACING);
 
                 if (attr.isItemLocked(LockAttribute.LOCK_EMPTY) || attr.isItemLocked(LockAttribute.LOCK_POPULATED))

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/BasicDrawerModel.java
@@ -142,7 +142,7 @@ public final class BasicDrawerModel
                 StorageDrawers.rl("models/block/geometry/comp_drawers_count_area_3.json"),
                 StorageDrawers.rl("models/block/geometry/comp_drawers_ind_area_3.json"),
                 StorageDrawers.rl("models/block/geometry/comp_drawers_indbase_area_3.json"),
-                ModBlocks.getBlocksOfType(BlockCompDrawers.class).toArray(BlockDrawers[]::new));
+                    ModBlocks.getDrawersOfType(BlockCompDrawers.class).toArray(BlockDrawers[]::new));
         }
 
         private static BlockModel getBlockModel (ResourceLocation location) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/ProxyBuilderModel.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/ProxyBuilderModel.java
@@ -1,12 +1,13 @@
 package com.jaquadro.minecraft.storagedrawers.client.model;
 
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.client.renderer.block.model.BakedQuad;
-import net.minecraft.client.resources.model.BakedModel;
-import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.block.model.ItemOverrides;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,8 +15,8 @@ import java.util.Random;
 
 public abstract class ProxyBuilderModel implements BakedModel
 {
-    private static final List<BakedQuad> EMPTY = new ArrayList<BakedQuad>(0);
-    private static final List<Object> EMPTY_KEY = new ArrayList<Object>();
+    private static final List<BakedQuad> EMPTY = new ArrayList<>(0);
+    private static final List<Object> EMPTY_KEY = new ArrayList<>();
 
     private BakedModel parent;
     private BakedModel proxy;
@@ -31,7 +32,8 @@ public abstract class ProxyBuilderModel implements BakedModel
     }
 
     @Override
-    public List<BakedQuad> getQuads (BlockState state, Direction side, Random rand) {
+    @NotNull
+    public List<BakedQuad> getQuads (BlockState state, Direction side, @NotNull Random rand) {
         if (proxy == null || stateCache != state)
             setProxy(state);
 
@@ -44,34 +46,37 @@ public abstract class ProxyBuilderModel implements BakedModel
     @Override
     public boolean useAmbientOcclusion () {
         BakedModel model = getActiveModel();
-        return (model != null) ? model.useAmbientOcclusion() : true;
+        return model == null || model.useAmbientOcclusion();
     }
 
     @Override
     public boolean isGui3d () {
         BakedModel model = getActiveModel();
-        return (model != null) ? model.isGui3d() : false;
+        return model != null && model.isGui3d();
     }
 
     @Override
     public boolean isCustomRenderer () {
         BakedModel model = getActiveModel();
-        return (model != null) ? model.isCustomRenderer() : false;
+        return model != null && model.isCustomRenderer();
     }
 
     @Override
+    @NotNull
     public TextureAtlasSprite getParticleIcon () {
         BakedModel model = getActiveModel();
         return (model != null) ? model.getParticleIcon() : iconParticle;
     }
 
     @Override
+    @NotNull
     public ItemTransforms getTransforms () {
         BakedModel model = getActiveModel();
         return (model != null) ? model.getTransforms() : ItemTransforms.NO_TRANSFORMS;
     }
 
     @Override
+    @NotNull
     public ItemOverrides getOverrides () {
         BakedModel model = getActiveModel();
         return (model != null) ? model.getOverrides() : ItemOverrides.EMPTY;
@@ -80,7 +85,7 @@ public abstract class ProxyBuilderModel implements BakedModel
     @Override
     public boolean usesBlockLight () {
         BakedModel model = getActiveModel();
-        return (model != null) ? model.usesBlockLight() : false;
+        return model != null && model.usesBlockLight();
     }
 
     public List<Object> getKey (BlockState state) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/BlockEntityDrawersRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/BlockEntityDrawersRenderer.java
@@ -14,6 +14,7 @@ import com.mojang.math.Matrix3f;
 import com.mojang.math.Matrix4f;
 import com.mojang.math.Quaternion;
 import com.mojang.math.Vector3f;
+import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -170,6 +171,13 @@ public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEnti
         matrix.popPose();
     }
 
+    private static final Quaternion ITEM_LIGHT_ROTATION_3D = Util.make(() -> {
+        Quaternion quaternion = new Quaternion(Vector3f.XP, -15f, true);
+        quaternion.mul(new Quaternion(Vector3f.YP, 15f, true));
+        return quaternion;
+    });
+    private static final Quaternion ITEM_LIGHT_ROTATION_FLAT = new Quaternion(Vector3f.XP, -45f, true);
+
     private void renderFastItem(@NotNull ItemStack itemStack, BlockState state, int slot, PoseStack matrix, MultiBufferSource buffer, int combinedLight, int combinedOverlay, Direction side) {
         BlockDrawers block = (BlockDrawers)state.getBlock();
         AABB labelGeometry = block.labelGeometry[slot];
@@ -188,6 +196,12 @@ public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEnti
 
         try {
             BakedModel itemModel = itemRenderer.getModel(itemStack, null, null, 0);
+
+            if (itemModel.isGui3d())
+                matrix.last().normal().mul(ITEM_LIGHT_ROTATION_3D);
+            else
+                matrix.last().normal().mul(ITEM_LIGHT_ROTATION_FLAT);
+
             itemRenderer.render(itemStack, ItemTransforms.TransformType.GUI, false, matrix, buffer, combinedLight, combinedOverlay, itemModel);
         } catch (Exception e) {
             // Shrug

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/BlockEntityDrawersRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/BlockEntityDrawersRenderer.java
@@ -4,8 +4,8 @@ import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.storage.Drawers;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawersComp;
 import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
 import com.jaquadro.minecraft.storagedrawers.util.CountFormatter;
 import com.mojang.blaze3d.platform.Lighting;
@@ -39,7 +39,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 
 @OnlyIn(Dist.CLIENT)
-public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntityDrawers>
+public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEntityDrawers>
 {
     private final ItemStack[] renderStacks = new ItemStack[4];
 
@@ -47,30 +47,30 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
 
     private final BlockEntityRendererProvider.Context context;
 
-    public TileEntityDrawersRenderer(BlockEntityRendererProvider.Context context) {
+    public BlockEntityDrawersRenderer(BlockEntityRendererProvider.Context context) {
         this.context = context;
     }
 
     @Override
-    public void render (@NotNull TileEntityDrawers tileEntityDrawers, float partialTickTime, @NotNull PoseStack matrix, @NotNull MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
+    public void render (@NotNull BlockEntityDrawers blockEntityDrawers, float partialTickTime, @NotNull PoseStack matrix, @NotNull MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
 
         Player player = Minecraft.getInstance().player;
         if (player == null)
             return;
 
-        Level level = tileEntityDrawers.getLevel();
+        Level level = blockEntityDrawers.getLevel();
         if (level == null)
             return;
 
-        BlockState state = tileEntityDrawers.getBlockState();
+        BlockState state = blockEntityDrawers.getBlockState();
         if (!(state.getBlock() instanceof BlockDrawers))
             return;
 
         Direction side = state.getValue(BlockDrawers.FACING);
-        if (playerBehindBlock(tileEntityDrawers.getBlockPos(), side))
+        if (playerBehindBlock(blockEntityDrawers.getBlockPos(), side))
             return;
 
-        float distance = (float)Math.sqrt(tileEntityDrawers.getBlockPos().distToCenterSqr(player.position()));
+        float distance = (float)Math.sqrt(blockEntityDrawers.getBlockPos().distToCenterSqr(player.position()));
 
         double renderDistance = ClientConfig.RENDER.labelRenderDistance.get();
         if (renderDistance > 0 && distance > renderDistance)
@@ -78,16 +78,16 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
 
         itemRenderer = Minecraft.getInstance().getItemRenderer();
 
-        if (tileEntityDrawers.upgrades().hasIlluminationUpgrade()) {
+        if (blockEntityDrawers.upgrades().hasIlluminationUpgrade()) {
             int blockLight = Math.max(combinedLight % 65536, 208);
             combinedLight = (combinedLight & 0xFFFF0000) | blockLight;
         }
 
-        if (!tileEntityDrawers.getDrawerAttributes().isConcealed())
-            renderFastItemSet(tileEntityDrawers, state, matrix, buffer, combinedLight, combinedOverlay, side, partialTickTime, distance);
+        if (!blockEntityDrawers.getDrawerAttributes().isConcealed())
+            renderFastItemSet(blockEntityDrawers, state, matrix, buffer, combinedLight, combinedOverlay, side, partialTickTime, distance);
 
-        if (tileEntityDrawers.getDrawerAttributes().hasFillLevel())
-            renderIndicator((BlockDrawers)state.getBlock(), tileEntityDrawers, matrix, buffer, state.getValue(BlockDrawers.FACING), combinedLight, combinedOverlay);
+        if (blockEntityDrawers.getDrawerAttributes().hasFillLevel())
+            renderIndicator((BlockDrawers)state.getBlock(), blockEntityDrawers, matrix, buffer, state.getValue(BlockDrawers.FACING), combinedLight, combinedOverlay);
 
         matrix.popPose();
         Lighting.setupLevel(matrix.last().pose());
@@ -109,12 +109,12 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
         };
     }
 
-    private void renderFastItemSet (TileEntityDrawers tileEntityDrawers, BlockState state, PoseStack matrix, MultiBufferSource buffer, int combinedLight, int combinedOverlay, Direction side, float partialTickTime, float distance) {
-        int drawerCount = tileEntityDrawers.getGroup().getDrawerCount();
+    private void renderFastItemSet (BlockEntityDrawers blockEntityDrawers, BlockState state, PoseStack matrix, MultiBufferSource buffer, int combinedLight, int combinedOverlay, Direction side, float partialTickTime, float distance) {
+        int drawerCount = blockEntityDrawers.getGroup().getDrawerCount();
 
         for (int i = 0; i < drawerCount; i++) {
             renderStacks[i] = ItemStack.EMPTY;
-            IDrawer drawer = tileEntityDrawers.getGroup().getDrawer(i);
+            IDrawer drawer = blockEntityDrawers.getGroup().getDrawer(i);
             if (!drawer.isEnabled() || drawer.isEmpty())
                 continue;
 
@@ -128,7 +128,7 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
                 renderFastItem(itemStack, state, i, matrix, buffer, combinedLight, combinedOverlay, side);
         }
 
-        if (tileEntityDrawers.getDrawerAttributes().isShowingQuantity()) {
+        if (blockEntityDrawers.getDrawerAttributes().isShowingQuantity()) {
             float alpha = 1;
             double fadeDistance = ClientConfig.RENDER.quantityFadeDistance.get();
             if (fadeDistance == 0 || distance > fadeDistance)
@@ -137,7 +137,7 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
             double renderDistance = ClientConfig.RENDER.quantityRenderDistance.get();
             if (renderDistance == 0 || distance < renderDistance) {
                 for (int i = 0; i < drawerCount; i++) {
-                    String format = CountFormatter.format(this.context.getFont(), tileEntityDrawers.getGroup().getDrawer(i));
+                    String format = CountFormatter.format(this.context.getFont(), blockEntityDrawers.getGroup().getDrawer(i));
                     renderText(format, state, i, matrix, buffer, combinedLight, side, alpha);
                 }
             }
@@ -240,11 +240,11 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
     public static final ResourceLocation TEXTURE_IND_4 = StorageDrawers.rl("blocks/indicator/indicator_4_on");
     public static final ResourceLocation TEXTURE_IND_COMP = StorageDrawers.rl("blocks/indicator/indicator_comp_on");
 
-    private void renderIndicator (BlockDrawers block, TileEntityDrawers tileEntityDrawers, PoseStack matrixStack, MultiBufferSource buffer, Direction side, int combinedLight, int combinedOverlay) {
-        int count = (tileEntityDrawers instanceof TileEntityDrawersComp) ? 1 : block.getDrawerCount();
+    private void renderIndicator (BlockDrawers block, BlockEntityDrawers blockEntityDrawers, PoseStack matrixStack, MultiBufferSource buffer, Direction side, int combinedLight, int combinedOverlay) {
+        int count = (blockEntityDrawers instanceof BlockEntityDrawersComp) ? 1 : block.getDrawerCount();
 
         ResourceLocation resource = TEXTURE_IND_1;
-        if (tileEntityDrawers instanceof TileEntityDrawersComp)
+        if (blockEntityDrawers instanceof BlockEntityDrawersComp)
             resource = TEXTURE_IND_COMP;
         else if (count == 2)
             resource = TEXTURE_IND_2;
@@ -268,8 +268,8 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
         alignRendering(matrixStack, side);
 
         for (int i = 0; i < count; i++) {
-            IDrawer drawer = tileEntityDrawers.getGroup().getDrawer(i);
-            if (drawer == Drawers.DISABLED || tileEntityDrawers.getDrawerAttributes().isConcealed())
+            IDrawer drawer = blockEntityDrawers.getGroup().getDrawer(i);
+            if (drawer == Drawers.DISABLED || blockEntityDrawers.getDrawerAttributes().isConcealed())
                 continue;
 
             AABB bb = block.indGeometry[i];
@@ -290,11 +290,11 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
             int stepX = (int)((x2 - xb2) * pxW);
             int stepY = (int)((y2 - yb2) * pxH);
 
-            float xCur = (stepX == 0) ? x2 : getIndEnd(tileEntityDrawers, i, x1, x2 - xb2, stepX);
+            float xCur = (stepX == 0) ? x2 : getIndEnd(blockEntityDrawers, i, x1, x2 - xb2, stepX);
             float xFrac = (x2 == xb2) ? 1 : (xCur - x1) / (x2 - xb2);
             float uCur = su1 + xFrac * (su2 - su1);
 
-            float yCur = (stepY == 0) ? y2 : getIndEnd(tileEntityDrawers, i, y1, y2 - yb2, stepY);
+            float yCur = (stepY == 0) ? y2 : getIndEnd(blockEntityDrawers, i, y1, y2 - yb2, stepY);
             float yFrac = (y2 == yb2) ? 1 : (yCur - y1) / (y2 - yb2);
             float vCur = sv1 + yFrac * (sv2 - sv1);
 
@@ -320,8 +320,8 @@ public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntity
         buffer.vertex(matrix, x, y, z).color(1f, 1f, 1f, 1f).uv(u, v).overlayCoords(combinedOverlay).uv2(combinedLight).normal(normal, 0, 1, 0).endVertex();
     }
 
-    private float getIndEnd (TileEntityDrawers tileEntityDrawers, int slot, float x, float w, int step) {
-        IDrawer drawer = tileEntityDrawers.getGroup().getDrawer(slot);
+    private float getIndEnd (BlockEntityDrawers blockEntityDrawers, int slot, float x, float w, int step) {
+        IDrawer drawer = blockEntityDrawers.getGroup().getDrawer(slot);
         if (drawer == Drawers.DISABLED)
             return x;
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/StorageRenderItem.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/StorageRenderItem.java
@@ -1,44 +1,38 @@
 package com.jaquadro.minecraft.storagedrawers.client.renderer;
 
 import com.jaquadro.minecraft.storagedrawers.inventory.ItemStackHelper;
-import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.blaze3d.vertex.*;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.client.gui.Font;
-import net.minecraft.client.renderer.*;
 import net.minecraft.client.color.item.ItemColors;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.ItemModelShaper;
+import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.model.BakedQuad;
-import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
-import net.minecraft.client.resources.model.ModelManager;
+import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.renderer.texture.TextureManager;
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import com.mojang.blaze3d.vertex.VertexFormat;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.Mth;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
-
-import com.mojang.blaze3d.vertex.BufferBuilder;
-import com.mojang.blaze3d.vertex.Tesselator;
-import net.minecraft.client.renderer.entity.ItemRenderer;
 
 @OnlyIn(Dist.CLIENT)
 public class StorageRenderItem extends ItemRenderer
 {
-    private ItemRenderer parent;
+    private final ItemRenderer parent;
 
-    @Nonnull
+    @NotNull
     public ItemStack overrideStack;
 
     public StorageRenderItem (TextureManager texManager, ModelManager modelManager, ItemColors colors) {
@@ -48,56 +42,58 @@ public class StorageRenderItem extends ItemRenderer
     }
 
     @Override
+    @NotNull
     public ItemModelShaper getItemModelShaper () {
         return parent.getItemModelShaper();
     }
 
     @Override
-    public void render(ItemStack itemStackIn, ItemTransforms.TransformType transformTypeIn, boolean leftHand, PoseStack matrixStackIn, MultiBufferSource bufferIn, int combinedLightIn, int combinedOverlayIn, BakedModel modelIn) {
+    public void render(@NotNull ItemStack itemStackIn, ItemTransforms.@NotNull TransformType transformTypeIn, boolean leftHand, @NotNull PoseStack matrixStackIn, @NotNull MultiBufferSource bufferIn, int combinedLightIn, int combinedOverlayIn, @NotNull BakedModel modelIn) {
         parent.render(itemStackIn, transformTypeIn, leftHand, matrixStackIn, bufferIn, combinedLightIn, combinedOverlayIn, modelIn);
     }
 
     @Override
-    public void renderStatic(@Nullable LivingEntity livingEntityIn, ItemStack itemStackIn, ItemTransforms.TransformType transformTypeIn, boolean leftHand, PoseStack matrixStackIn, MultiBufferSource bufferIn, @Nullable Level worldIn, int combinedLightIn, int combinedOverlayIn, int p_174252_) {
+    public void renderStatic(@Nullable LivingEntity livingEntityIn, @NotNull ItemStack itemStackIn, ItemTransforms.@NotNull TransformType transformTypeIn, boolean leftHand, @NotNull PoseStack matrixStackIn, MultiBufferSource bufferIn, @Nullable Level worldIn, int combinedLightIn, int combinedOverlayIn, int p_174252_) {
         parent.renderStatic(livingEntityIn, itemStackIn, transformTypeIn, leftHand, matrixStackIn, bufferIn, worldIn, combinedLightIn, combinedOverlayIn, p_174252_);
     }
 
     @Override
-    public void renderStatic(ItemStack itemStackIn, ItemTransforms.TransformType transformTypeIn, int combinedLightIn, int combinedOverlayIn, PoseStack matrixStackIn, MultiBufferSource bufferIn, int p_174276_) {
+    public void renderStatic(@NotNull ItemStack itemStackIn, ItemTransforms.@NotNull TransformType transformTypeIn, int combinedLightIn, int combinedOverlayIn, @NotNull PoseStack matrixStackIn, @NotNull MultiBufferSource bufferIn, int p_174276_) {
         parent.renderStatic(itemStackIn, transformTypeIn, combinedLightIn, combinedOverlayIn, matrixStackIn, bufferIn, p_174276_);
     }
 
-    public void renderQuadList(PoseStack matrixStackIn, VertexConsumer bufferIn, List<BakedQuad> quadsIn, ItemStack itemStackIn, int combinedLightIn, int combinedOverlayIn) {
+    public void renderQuadList(@NotNull PoseStack matrixStackIn, @NotNull VertexConsumer bufferIn, @NotNull List<BakedQuad> quadsIn, @NotNull ItemStack itemStackIn, int combinedLightIn, int combinedOverlayIn) {
         parent.renderQuadList(matrixStackIn, bufferIn, quadsIn, itemStackIn, combinedLightIn, combinedOverlayIn);
     }
 
     @Override
-    public BakedModel getModel (@Nonnull ItemStack stack, Level world, LivingEntity entity, int p_174268_) {
+    @NotNull
+    public BakedModel getModel (@NotNull ItemStack stack, Level world, LivingEntity entity, int p_174268_) {
         return parent.getModel(stack, world, entity, p_174268_);
     }
 
     @Override
-    public void renderGuiItem (@Nonnull ItemStack stack, int x, int y) {
+    public void renderGuiItem (@NotNull ItemStack stack, int x, int y) {
         parent.renderGuiItem(stack, x, y);
     }
 
     @Override
-    public void renderAndDecorateItem (@Nonnull ItemStack stack, int xPosition, int yPosition) {
+    public void renderAndDecorateItem (@NotNull ItemStack stack, int xPosition, int yPosition) {
         parent.renderAndDecorateItem(stack, xPosition, yPosition);
     }
 
     @Override
-    public void renderAndDecorateItem(@Nullable LivingEntity entityIn, ItemStack itemIn, int x, int y, int p_174234_) {
+    public void renderAndDecorateItem(@NotNull LivingEntity entityIn, @NotNull ItemStack itemIn, int x, int y, int p_174234_) {
         parent.renderAndDecorateItem(entityIn, itemIn, x, y, p_174234_);
     }
 
     @Override
-    public void renderGuiItemDecorations (Font fr, @Nonnull ItemStack stack, int xPosition, int yPosition) {
+    public void renderGuiItemDecorations (@NotNull Font fr, @NotNull ItemStack stack, int xPosition, int yPosition) {
         parent.renderGuiItemDecorations(fr, stack, xPosition, yPosition);
     }
 
     @Override
-    public void renderGuiItemDecorations (Font font, @Nonnull ItemStack item, int x, int y, String text)
+    public void renderGuiItemDecorations (@NotNull Font font, @NotNull ItemStack item, int x, int y, String text)
     {
         if (item != overrideStack) {
             super.renderGuiItemDecorations(font, item, x, y, text);
@@ -178,7 +174,7 @@ public class StorageRenderItem extends ItemRenderer
     }
 
     @Override
-    public void onResourceManagerReload (ResourceManager p_195410_1_) {
+    public void onResourceManagerReload (@NotNull ResourceManager p_195410_1_) {
         parent.onResourceManagerReload(p_195410_1_);
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/StorageRenderItem.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/StorageRenderItem.java
@@ -53,7 +53,7 @@ public class StorageRenderItem extends ItemRenderer
     }
 
     @Override
-    public void renderStatic(@Nullable LivingEntity livingEntityIn, @NotNull ItemStack itemStackIn, ItemTransforms.@NotNull TransformType transformTypeIn, boolean leftHand, @NotNull PoseStack matrixStackIn, MultiBufferSource bufferIn, @Nullable Level worldIn, int combinedLightIn, int combinedOverlayIn, int p_174252_) {
+    public void renderStatic(@Nullable LivingEntity livingEntityIn, @NotNull ItemStack itemStackIn, ItemTransforms.@NotNull TransformType transformTypeIn, boolean leftHand, @NotNull PoseStack matrixStackIn, @NotNull MultiBufferSource bufferIn, @Nullable Level worldIn, int combinedLightIn, int combinedOverlayIn, int p_174252_) {
         parent.renderStatic(livingEntityIn, itemStackIn, transformTypeIn, leftHand, matrixStackIn, bufferIn, worldIn, combinedLightIn, combinedOverlayIn, p_174252_);
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
@@ -4,8 +4,8 @@ import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.storage.Drawers;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawersComp;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp;
 import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
 import com.jaquadro.minecraft.storagedrawers.util.CountFormatter;
 import com.mojang.blaze3d.platform.Lighting;
@@ -39,7 +39,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 
 @OnlyIn(Dist.CLIENT)
-public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEntityDrawers>
+public class TileEntityDrawersRenderer implements BlockEntityRenderer<TileEntityDrawers>
 {
     private final ItemStack[] renderStacks = new ItemStack[4];
 
@@ -47,30 +47,30 @@ public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEnti
 
     private final BlockEntityRendererProvider.Context context;
 
-    public BlockEntityDrawersRenderer(BlockEntityRendererProvider.Context context) {
+    public TileEntityDrawersRenderer(BlockEntityRendererProvider.Context context) {
         this.context = context;
     }
 
     @Override
-    public void render (@NotNull BlockEntityDrawers blockEntityDrawers, float partialTickTime, @NotNull PoseStack matrix, @NotNull MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
+    public void render (@NotNull TileEntityDrawers tileEntityDrawers, float partialTickTime, @NotNull PoseStack matrix, @NotNull MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
 
         Player player = Minecraft.getInstance().player;
         if (player == null)
             return;
 
-        Level level = blockEntityDrawers.getLevel();
+        Level level = tileEntityDrawers.getLevel();
         if (level == null)
             return;
 
-        BlockState state = blockEntityDrawers.getBlockState();
+        BlockState state = tileEntityDrawers.getBlockState();
         if (!(state.getBlock() instanceof BlockDrawers))
             return;
 
         Direction side = state.getValue(BlockDrawers.FACING);
-        if (playerBehindBlock(blockEntityDrawers.getBlockPos(), side))
+        if (playerBehindBlock(tileEntityDrawers.getBlockPos(), side))
             return;
 
-        float distance = (float)Math.sqrt(blockEntityDrawers.getBlockPos().distToCenterSqr(player.position()));
+        float distance = (float)Math.sqrt(tileEntityDrawers.getBlockPos().distToCenterSqr(player.position()));
 
         double renderDistance = ClientConfig.RENDER.labelRenderDistance.get();
         if (renderDistance > 0 && distance > renderDistance)
@@ -78,16 +78,16 @@ public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEnti
 
         itemRenderer = Minecraft.getInstance().getItemRenderer();
 
-        if (blockEntityDrawers.upgrades().hasIlluminationUpgrade()) {
+        if (tileEntityDrawers.upgrades().hasIlluminationUpgrade()) {
             int blockLight = Math.max(combinedLight % 65536, 208);
             combinedLight = (combinedLight & 0xFFFF0000) | blockLight;
         }
 
-        if (!blockEntityDrawers.getDrawerAttributes().isConcealed())
-            renderFastItemSet(blockEntityDrawers, state, matrix, buffer, combinedLight, combinedOverlay, side, partialTickTime, distance);
+        if (!tileEntityDrawers.getDrawerAttributes().isConcealed())
+            renderFastItemSet(tileEntityDrawers, state, matrix, buffer, combinedLight, combinedOverlay, side, partialTickTime, distance);
 
-        if (blockEntityDrawers.getDrawerAttributes().hasFillLevel())
-            renderIndicator((BlockDrawers)state.getBlock(), blockEntityDrawers, matrix, buffer, state.getValue(BlockDrawers.FACING), combinedLight, combinedOverlay);
+        if (tileEntityDrawers.getDrawerAttributes().hasFillLevel())
+            renderIndicator((BlockDrawers)state.getBlock(), tileEntityDrawers, matrix, buffer, state.getValue(BlockDrawers.FACING), combinedLight, combinedOverlay);
 
         matrix.popPose();
         Lighting.setupLevel(matrix.last().pose());
@@ -109,12 +109,12 @@ public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEnti
         };
     }
 
-    private void renderFastItemSet (BlockEntityDrawers blockEntityDrawers, BlockState state, PoseStack matrix, MultiBufferSource buffer, int combinedLight, int combinedOverlay, Direction side, float partialTickTime, float distance) {
-        int drawerCount = blockEntityDrawers.getGroup().getDrawerCount();
+    private void renderFastItemSet (TileEntityDrawers tileEntityDrawers, BlockState state, PoseStack matrix, MultiBufferSource buffer, int combinedLight, int combinedOverlay, Direction side, float partialTickTime, float distance) {
+        int drawerCount = tileEntityDrawers.getGroup().getDrawerCount();
 
         for (int i = 0; i < drawerCount; i++) {
             renderStacks[i] = ItemStack.EMPTY;
-            IDrawer drawer = blockEntityDrawers.getGroup().getDrawer(i);
+            IDrawer drawer = tileEntityDrawers.getGroup().getDrawer(i);
             if (!drawer.isEnabled() || drawer.isEmpty())
                 continue;
 
@@ -128,7 +128,7 @@ public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEnti
                 renderFastItem(itemStack, state, i, matrix, buffer, combinedLight, combinedOverlay, side);
         }
 
-        if (blockEntityDrawers.getDrawerAttributes().isShowingQuantity()) {
+        if (tileEntityDrawers.getDrawerAttributes().isShowingQuantity()) {
             float alpha = 1;
             double fadeDistance = ClientConfig.RENDER.quantityFadeDistance.get();
             if (fadeDistance == 0 || distance > fadeDistance)
@@ -137,7 +137,7 @@ public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEnti
             double renderDistance = ClientConfig.RENDER.quantityRenderDistance.get();
             if (renderDistance == 0 || distance < renderDistance) {
                 for (int i = 0; i < drawerCount; i++) {
-                    String format = CountFormatter.format(this.context.getFont(), blockEntityDrawers.getGroup().getDrawer(i));
+                    String format = CountFormatter.format(this.context.getFont(), tileEntityDrawers.getGroup().getDrawer(i));
                     renderText(format, state, i, matrix, buffer, combinedLight, side, alpha);
                 }
             }
@@ -240,11 +240,11 @@ public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEnti
     public static final ResourceLocation TEXTURE_IND_4 = StorageDrawers.rl("blocks/indicator/indicator_4_on");
     public static final ResourceLocation TEXTURE_IND_COMP = StorageDrawers.rl("blocks/indicator/indicator_comp_on");
 
-    private void renderIndicator (BlockDrawers block, BlockEntityDrawers blockEntityDrawers, PoseStack matrixStack, MultiBufferSource buffer, Direction side, int combinedLight, int combinedOverlay) {
-        int count = (blockEntityDrawers instanceof BlockEntityDrawersComp) ? 1 : block.getDrawerCount();
+    private void renderIndicator (BlockDrawers block, TileEntityDrawers tileEntityDrawers, PoseStack matrixStack, MultiBufferSource buffer, Direction side, int combinedLight, int combinedOverlay) {
+        int count = (tileEntityDrawers instanceof TileEntityDrawersComp) ? 1 : block.getDrawerCount();
 
         ResourceLocation resource = TEXTURE_IND_1;
-        if (blockEntityDrawers instanceof BlockEntityDrawersComp)
+        if (tileEntityDrawers instanceof TileEntityDrawersComp)
             resource = TEXTURE_IND_COMP;
         else if (count == 2)
             resource = TEXTURE_IND_2;
@@ -268,8 +268,8 @@ public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEnti
         alignRendering(matrixStack, side);
 
         for (int i = 0; i < count; i++) {
-            IDrawer drawer = blockEntityDrawers.getGroup().getDrawer(i);
-            if (drawer == Drawers.DISABLED || blockEntityDrawers.getDrawerAttributes().isConcealed())
+            IDrawer drawer = tileEntityDrawers.getGroup().getDrawer(i);
+            if (drawer == Drawers.DISABLED || tileEntityDrawers.getDrawerAttributes().isConcealed())
                 continue;
 
             AABB bb = block.indGeometry[i];
@@ -290,11 +290,11 @@ public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEnti
             int stepX = (int)((x2 - xb2) * pxW);
             int stepY = (int)((y2 - yb2) * pxH);
 
-            float xCur = (stepX == 0) ? x2 : getIndEnd(blockEntityDrawers, i, x1, x2 - xb2, stepX);
+            float xCur = (stepX == 0) ? x2 : getIndEnd(tileEntityDrawers, i, x1, x2 - xb2, stepX);
             float xFrac = (x2 == xb2) ? 1 : (xCur - x1) / (x2 - xb2);
             float uCur = su1 + xFrac * (su2 - su1);
 
-            float yCur = (stepY == 0) ? y2 : getIndEnd(blockEntityDrawers, i, y1, y2 - yb2, stepY);
+            float yCur = (stepY == 0) ? y2 : getIndEnd(tileEntityDrawers, i, y1, y2 - yb2, stepY);
             float yFrac = (y2 == yb2) ? 1 : (yCur - y1) / (y2 - yb2);
             float vCur = sv1 + yFrac * (sv2 - sv1);
 
@@ -320,8 +320,8 @@ public class BlockEntityDrawersRenderer implements BlockEntityRenderer<BlockEnti
         buffer.vertex(matrix, x, y, z).color(1f, 1f, 1f, 1f).uv(u, v).overlayCoords(combinedOverlay).uv2(combinedLight).normal(normal, 0, 1, 0).endVertex();
     }
 
-    private float getIndEnd (BlockEntityDrawers blockEntityDrawers, int slot, float x, float w, int step) {
-        IDrawer drawer = blockEntityDrawers.getGroup().getDrawer(slot);
+    private float getIndEnd (TileEntityDrawers tileEntityDrawers, int slot, float x, float w, int step) {
+        IDrawer drawer = tileEntityDrawers.getGroup().getDrawer(slot);
         if (drawer == Drawers.DISABLED)
             return x;
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/config/ClientConfig.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/config/ClientConfig.java
@@ -14,7 +14,7 @@ public class ClientConfig
     public static final ForgeConfigSpec spec = BUILDER.build();
 
     private static boolean loaded = false;
-    private static List<Runnable> loadActions = new ArrayList<>();
+    private static final List<Runnable> loadActions = new ArrayList<>();
 
     public static void setLoaded() {
         if (!loaded)

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/config/CommonConfig.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/config/CommonConfig.java
@@ -4,7 +4,6 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
 
 public final class CommonConfig
 {
@@ -15,7 +14,7 @@ public final class CommonConfig
     public static final ForgeConfigSpec spec = BUILDER.build();
 
     private static boolean loaded = false;
-    private static List<Runnable> loadActions = new ArrayList<>();
+    private static final List<Runnable> loadActions = new ArrayList<>();
 
     public static void setLoaded() {
         if (!loaded)
@@ -143,14 +142,14 @@ public final class CommonConfig
             if (!isLoaded())
                 return 1;
 
-            switch (level) {
-                case 1: return level1Mult.get();
-                case 2: return level2Mult.get();
-                case 3: return level3Mult.get();
-                case 4: return level4Mult.get();
-                case 5: return level5Mult.get();
-                default: return 1;
-            }
+            return switch (level) {
+                case 1 -> level1Mult.get();
+                case 2 -> level2Mult.get();
+                case 3 -> level3Mult.get();
+                case 4 -> level4Mult.get();
+                case 5 -> level5Mult.get();
+                default -> 1;
+            };
         }
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/config/CompTierRegistry.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/config/CompTierRegistry.java
@@ -1,36 +1,36 @@
 package com.jaquadro.minecraft.storagedrawers.config;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import net.minecraft.world.level.block.Blocks;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
 public class CompTierRegistry
 {
-    public class Record {
-        @Nonnull
+    public static class Record {
+        @NotNull
         public final ItemStack upper;
-        @Nonnull
+        @NotNull
         public final ItemStack lower;
         public final int convRate;
 
-        public Record (@Nonnull ItemStack upper, @Nonnull ItemStack lower, int convRate) {
+        public Record (@NotNull ItemStack upper, @NotNull ItemStack lower, int convRate) {
             this.upper = upper;
             this.lower = lower;
             this.convRate = convRate;
         }
     }
 
-    private List<Record> records = new ArrayList<Record>();
-    private List<String> pendingRules = new ArrayList<String>();
+    private final List<Record> records = new ArrayList<>();
+    private List<String> pendingRules = new ArrayList<>();
     private boolean initialized;
 
     public CompTierRegistry () { }
@@ -63,7 +63,7 @@ public class CompTierRegistry
         pendingRules = null;
     }
 
-    public boolean register (@Nonnull ItemStack upper, @Nonnull ItemStack lower, int convRate) {
+    public boolean register (@NotNull ItemStack upper, @NotNull ItemStack lower, int convRate) {
         if (upper.isEmpty() || lower.isEmpty())
             return false;
 
@@ -132,7 +132,7 @@ public class CompTierRegistry
         }
     }
 
-    public boolean unregisterUpperTarget (@Nonnull ItemStack stack) {
+    public boolean unregisterUpperTarget (@NotNull ItemStack stack) {
         for (Record r : records) {
             if (ItemStack.matches(stack, r.upper)) {
                 records.remove(r);
@@ -143,7 +143,7 @@ public class CompTierRegistry
         return false;
     }
 
-    public boolean unregisterLowerTarget (@Nonnull ItemStack stack) {
+    public boolean unregisterLowerTarget (@NotNull ItemStack stack) {
         for (Record r : records) {
             if (ItemStack.matches(stack, r.lower)) {
                 records.remove(r);
@@ -154,7 +154,7 @@ public class CompTierRegistry
         return false;
     }
 
-    public Record findHigherTier (@Nonnull ItemStack stack) {
+    public Record findHigherTier (@NotNull ItemStack stack) {
         if (stack.isEmpty())
             return null;
 
@@ -166,7 +166,7 @@ public class CompTierRegistry
         return null;
     }
 
-    public Record findLowerTier (@Nonnull ItemStack stack) {
+    public Record findLowerTier (@NotNull ItemStack stack) {
         if (stack.isEmpty())
             return null;
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/config/RenderRegistry.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/config/RenderRegistry.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class RenderRegistry implements IRenderRegistry
 {
-    private List<IRenderLabel> registry = new ArrayList<>();
+    private final List<IRenderLabel> registry = new ArrayList<>();
 
     @Override
     public void registerPreLabelRenderHandler (IRenderLabel renderHandler) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/config/WailaRegistry.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/config/WailaRegistry.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class WailaRegistry implements IWailaRegistry
 {
-    private List<IWailaTooltipHandler> registry = new ArrayList<>();
+    private final List<IWailaTooltipHandler> registry = new ArrayList<>();
 
     @Override
     public void registerTooltipHandler (IWailaTooltipHandler handler) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/Api.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/Api.java
@@ -1,9 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.core;
 
-import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.IStorageDrawersApi;
-import com.jaquadro.minecraft.storagedrawers.api.registry.IRenderRegistry;
-import com.jaquadro.minecraft.storagedrawers.api.registry.IWailaRegistry;
 
 public class Api implements IStorageDrawersApi
 {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ClientProxy.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ClientProxy.java
@@ -1,29 +1,29 @@
-package com.jaquadro.minecraft.storagedrawers.core;
-
-public class ClientProxy extends CommonProxy
-{
-    @Override
-    public void registerRenderers () {
-        /*IconRegistry iconRegistry = Chameleon.instance.iconRegistry;
-        iconRegistry.registerIcon(iconConcealmentOverlayResource);
-        iconRegistry.registerIcon(iconIndicatorCompOnResource);
-        iconRegistry.registerIcon(iconIndicatorCompOffResource);
-
-        for (int i = 0; i < 5; i++) {
-            if (iconIndicatorOffResource[i] != null)
-                iconRegistry.registerIcon(iconIndicatorOffResource[i]);
-            if (iconIndicatorOnResource[i] != null)
-                iconRegistry.registerIcon(iconIndicatorOnResource[i]);
-        }*/
-    }
-
-    /*
-    @SubscribeEvent
-    public void onEntityJoinWorldEvent(net.minecraftforge.event.entity.EntityJoinWorldEvent event) {
-        if (!event.getEntity().getEntityWorld().isRemote || !(event.getEntity() instanceof EntityPlayer))
-            return;
-
-        if (event.getEntity().getEntityId() == FMLClientHandler.instance().getClientPlayerEntity().getEntityId())
-            StorageDrawers.network.sendToServer(new BoolConfigUpdateMessage(FMLClientHandler.instance().getClientPlayerEntity().getUniqueID().toString(), "invertShift", StorageDrawers.config.cache.invertShift));
-    }*/
-}
+//package com.jaquadro.minecraft.storagedrawers.core;
+//
+//public class ClientProxy extends CommonProxy
+//{
+//    @Override
+//    public void registerRenderers () {
+//        /*IconRegistry iconRegistry = Chameleon.instance.iconRegistry;
+//        iconRegistry.registerIcon(iconConcealmentOverlayResource);
+//        iconRegistry.registerIcon(iconIndicatorCompOnResource);
+//        iconRegistry.registerIcon(iconIndicatorCompOffResource);
+//
+//        for (int i = 0; i < 5; i++) {
+//            if (iconIndicatorOffResource[i] != null)
+//                iconRegistry.registerIcon(iconIndicatorOffResource[i]);
+//            if (iconIndicatorOnResource[i] != null)
+//                iconRegistry.registerIcon(iconIndicatorOnResource[i]);
+//        }*/
+//    }
+//
+//    /*
+//    @SubscribeEvent
+//    public void onEntityJoinWorldEvent(net.minecraftforge.event.entity.EntityJoinWorldEvent event) {
+//        if (!event.getEntity().getEntityWorld().isRemote || !(event.getEntity() instanceof EntityPlayer))
+//            return;
+//
+//        if (event.getEntity().getEntityId() == FMLClientHandler.instance().getClientPlayerEntity().getEntityId())
+//            StorageDrawers.network.sendToServer(new BoolConfigUpdateMessage(FMLClientHandler.instance().getClientPlayerEntity().getUniqueID().toString(), "invertShift", StorageDrawers.config.cache.invertShift));
+//    }*/
+//}

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/CommonEventBusSubscriber.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/CommonEventBusSubscriber.java
@@ -1,0 +1,28 @@
+package com.jaquadro.minecraft.storagedrawers.core;
+
+import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.jetbrains.annotations.NotNull;
+
+@Mod.EventBusSubscriber(modid = StorageDrawers.MOD_ID)
+public class CommonEventBusSubscriber {
+    @SubscribeEvent
+    public static void playerLeftClick (@NotNull PlayerInteractEvent.LeftClickBlock event) {
+        BlockPos pos = event.getPos();
+        BlockState state = event.getWorld().getBlockState(pos);
+        Block block = state.getBlock();
+        if (block instanceof BlockDrawers blockDrawers) {
+            Player player = event.getPlayer();
+            if (player.isCreative()) {
+                event.setCanceled(blockDrawers.interactTakeItems(state, event.getWorld(), pos, player));
+            }
+        }
+    }
+}

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/CommonEventBusSubscriber.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/CommonEventBusSubscriber.java
@@ -4,6 +4,7 @@ import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -16,12 +17,13 @@ public class CommonEventBusSubscriber {
     @SubscribeEvent
     public static void playerLeftClick (@NotNull PlayerInteractEvent.LeftClickBlock event) {
         BlockPos pos = event.getPos();
-        BlockState state = event.getWorld().getBlockState(pos);
+        Level level = event.getWorld();
+        BlockState state = level.getBlockState(pos);
         Block block = state.getBlock();
         if (block instanceof BlockDrawers blockDrawers) {
             Player player = event.getPlayer();
             if (player.isCreative()) {
-                event.setCanceled(blockDrawers.interactTakeItems(state, event.getWorld(), pos, player));
+                event.setCanceled(blockDrawers.interactTakeItems(state, level, pos, player));
             }
         }
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/CommonProxy.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/CommonProxy.java
@@ -1,77 +1,73 @@
-package com.jaquadro.minecraft.storagedrawers.core;
-
-import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.core.BlockPos;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.entity.player.PlayerInteractEvent;
-import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-
-public class CommonProxy
-{
-    /*public final ResourceLocation iconConcealmentOverlayResource = new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/overlay/shading_concealment");
-    public final ResourceLocation iconIndicatorCompOnResource = new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_comp_on");
-    public final ResourceLocation iconIndicatorCompOffResource = new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_comp_off");
-
-    public final ResourceLocation[] iconIndicatorOnResource = new ResourceLocation[] {
-        null,
-        new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_1_on"),
-        new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_2_on"),
-        null,
-        new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_4_on"),
-    };
-    public final ResourceLocation[] iconIndicatorOffResource = new ResourceLocation[] {
-        null,
-        new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_1_off"),
-        new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_2_off"),
-        null,
-        new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_4_off"),
-    };*/
-
-    public CommonProxy () {
-        MinecraftForge.EVENT_BUS.addListener(this::playerLeftClick);
-        MinecraftForge.EVENT_BUS.addListener(this::playerRightClick);
-    }
-
-    public void registerRenderers ()
-    { }
-
-    public void updatePlayerInventory (Player player) {
-        // TODO: Update line: if (player instanceof ServerPlayer)
-        // TODO: Update line:     ((ServerPlayer) player).refreshContainer(player.inventoryMenu);
-    }
-
-    private void playerLeftClick (PlayerInteractEvent.LeftClickBlock event) {
-        //if (event.getWorld().isRemote) {
-            BlockPos pos = event.getPos();
-            BlockState state = event.getWorld().getBlockState(pos);
-            Block block = state.getBlock();
-            if (block instanceof BlockDrawers) {
-                if (event.getPlayer().isCreative()) {
-                    if (!((BlockDrawers) block).creativeCanBreakBlock(state, event.getWorld(), pos, event.getPlayer())) {
-                        state.attack(event.getWorld(), pos, event.getPlayer());
-                        event.setCanceled(true);
-                    }
-                }
-            }
-        //}
-    }
-
-    private void playerRightClick (PlayerInteractEvent.RightClickBlock event) {
-        if (event.getHand() == InteractionHand.MAIN_HAND && event.getItemStack().isEmpty()) {
-            BlockEntity tile = event.getWorld().getBlockEntity(event.getPos());
-            if (tile instanceof TileEntityDrawers) {
-                event.setUseBlock(Event.Result.ALLOW);
-            }
-        }
-    }
-}
+//package com.jaquadro.minecraft.storagedrawers.core;
+//
+//import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
+//import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+//import net.minecraft.world.level.block.Block;
+//import net.minecraft.world.level.block.state.BlockState;
+//import net.minecraft.world.entity.player.Player;
+//import net.minecraft.world.level.block.entity.BlockEntity;
+//import net.minecraft.world.InteractionHand;
+//import net.minecraft.core.BlockPos;
+//import net.minecraftforge.common.MinecraftForge;
+//import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+//import net.minecraftforge.eventbus.api.Event;
+//
+//public class CommonProxy
+//{
+//    /*public final ResourceLocation iconConcealmentOverlayResource = new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/overlay/shading_concealment");
+//    public final ResourceLocation iconIndicatorCompOnResource = new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_comp_on");
+//    public final ResourceLocation iconIndicatorCompOffResource = new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_comp_off");
+//
+//    public final ResourceLocation[] iconIndicatorOnResource = new ResourceLocation[] {
+//        null,
+//        new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_1_on"),
+//        new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_2_on"),
+//        null,
+//        new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_4_on"),
+//    };
+//    public final ResourceLocation[] iconIndicatorOffResource = new ResourceLocation[] {
+//        null,
+//        new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_1_off"),
+//        new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_2_off"),
+//        null,
+//        new ResourceLocation(StorageDrawers.MOD_ID + ":blocks/indicator/indicator_4_off"),
+//    };*/
+//
+//    public CommonProxy () {
+//        MinecraftForge.EVENT_BUS.addListener(this::playerLeftClick);
+//        MinecraftForge.EVENT_BUS.addListener(this::playerRightClick);
+//    }
+//
+//    public void registerRenderers ()
+//    { }
+//
+//    public void updatePlayerInventory (Player player) {
+//        // TODO: Update line: if (player instanceof ServerPlayer)
+//        // TODO: Update line:     ((ServerPlayer) player).refreshContainer(player.inventoryMenu);
+//    }
+//
+//    private void playerLeftClick (PlayerInteractEvent.LeftClickBlock event) {
+//        //if (event.getWorld().isRemote) {
+//            BlockPos pos = event.getPos();
+//            BlockState state = event.getWorld().getBlockState(pos);
+//            Block block = state.getBlock();
+//            if (block instanceof BlockDrawers) {
+//                if (event.getPlayer().isCreative()) {
+//                    if (!((BlockDrawers) block).creativeCanBreakBlock(state, event.getWorld(), pos, event.getPlayer())) {
+//                        state.attack(event.getWorld(), pos, event.getPlayer());
+//                        event.setCanceled(true);
+//                    }
+//                }
+//            }
+//        //}
+//    }
+//
+//    private void playerRightClick (PlayerInteractEvent.RightClickBlock event) {
+//        if (event.getHand() == InteractionHand.MAIN_HAND && event.getItemStack().isEmpty()) {
+//            BlockEntity tile = event.getWorld().getBlockEntity(event.getPos());
+//            if (tile instanceof BlockEntityDrawers) {
+//                event.setUseBlock(Event.Result.ALLOW);
+//            }
+//        }
+//    }
+//}

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlockEntities.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlockEntities.java
@@ -19,28 +19,28 @@ import java.util.stream.Stream;
 public final class ModBlockEntities {
     public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITY_REGISTER = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITIES, StorageDrawers.MOD_ID);
 
-    private static final Set<RegistryObject<? extends BlockEntityType<? extends TileEntityDrawers>>> BLOCK_ENTITY_TYPES_WITH_RENDERERS = new HashSet<>();
+    private static final Set<RegistryObject<? extends BlockEntityType<? extends BlockEntityDrawers>>> BLOCK_ENTITY_TYPES_WITH_RENDERERS = new HashSet<>();
 
-    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_1 = registerDrawerBlockEntityType("standard_drawers_1", TileEntityDrawersStandard.Slot1::new, BlockStandardDrawers.class, 1);
-    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_2 = registerDrawerBlockEntityType("standard_drawers_2", TileEntityDrawersStandard.Slot2::new, BlockStandardDrawers.class, 2);
-    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_4 = registerDrawerBlockEntityType("standard_drawers_4", TileEntityDrawersStandard.Slot4::new, BlockStandardDrawers.class, 4);
-    public static final RegistryObject<BlockEntityType<TileEntityDrawersComp>> FRACTIONAL_DRAWERS_3 = registerDrawerBlockEntityType("fractional_drawers_3", TileEntityDrawersComp.Slot3::new, BlockCompDrawers.class, 3);
-    public static final RegistryObject<BlockEntityType<TileEntityController>> CONTROLLER = registerBlockEntityType("controller", TileEntityController::new, BlockController.class);
-    public static final RegistryObject<BlockEntityType<TileEntitySlave>> CONTROLLER_SLAVE = registerBlockEntityType("controller_slave", TileEntitySlave::new, BlockSlave.class);
+    public static final RegistryObject<BlockEntityType<BlockEntityDrawersStandard>> STANDARD_DRAWERS_1 = registerDrawerBlockEntityType("standard_drawers_1", BlockEntityDrawersStandard.Slot1::new, BlockStandardDrawers.class, 1);
+    public static final RegistryObject<BlockEntityType<BlockEntityDrawersStandard>> STANDARD_DRAWERS_2 = registerDrawerBlockEntityType("standard_drawers_2", BlockEntityDrawersStandard.Slot2::new, BlockStandardDrawers.class, 2);
+    public static final RegistryObject<BlockEntityType<BlockEntityDrawersStandard>> STANDARD_DRAWERS_4 = registerDrawerBlockEntityType("standard_drawers_4", BlockEntityDrawersStandard.Slot4::new, BlockStandardDrawers.class, 4);
+    public static final RegistryObject<BlockEntityType<BlockEntityDrawersComp>> FRACTIONAL_DRAWERS_3 = registerDrawerBlockEntityType("fractional_drawers_3", BlockEntityDrawersComp.Slot3::new, BlockCompDrawers.class, 3);
+    public static final RegistryObject<BlockEntityType<BlockEntityController>> CONTROLLER = registerBlockEntityType("controller", BlockEntityController::new, BlockController.class);
+    public static final RegistryObject<BlockEntityType<BlockEntitySlave>> CONTROLLER_SLAVE = registerBlockEntityType("controller_slave", BlockEntitySlave::new, BlockSlave.class);
 
     private ModBlockEntities() {}
 
-    private static <BE extends TileEntityDrawers, B extends BlockDrawers> RegistryObject<BlockEntityType<BE>> registerDrawerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Class<B> drawerBlockClass, int size) {
+    private static <BE extends BlockEntityDrawers, B extends BlockDrawers> RegistryObject<BlockEntityType<BE>> registerDrawerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Class<B> drawerBlockClass, int size) {
         RegistryObject<BlockEntityType<BE>> ro = registerBlockEntityType(name, blockEntitySupplier, ModBlocks.getDrawersOfTypeAndSize(drawerBlockClass, size));
         BLOCK_ENTITY_TYPES_WITH_RENDERERS.add(ro);
         return ro;
     }
 
-    private static <BE extends ChamTileEntity, B extends Block> RegistryObject<BlockEntityType<BE>> registerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Class<B> blockClass) {
+    private static <BE extends BaseBlockEntity, B extends Block> RegistryObject<BlockEntityType<BE>> registerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Class<B> blockClass) {
         return registerBlockEntityType(name, blockEntitySupplier, ModBlocks.getBlocksOfType(blockClass));
     }
 
-    private static <BE extends ChamTileEntity, B extends Block> RegistryObject<BlockEntityType<BE>> registerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Stream<B> blockStream) {
+    private static <BE extends BaseBlockEntity, B extends Block> RegistryObject<BlockEntityType<BE>> registerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Stream<B> blockStream) {
         return BLOCK_ENTITY_REGISTER.register(name, () -> BlockEntityType.Builder.of(blockEntitySupplier, blockStream.toArray(Block[]::new)).build(null));
     }
 
@@ -48,7 +48,7 @@ public final class ModBlockEntities {
         BLOCK_ENTITY_REGISTER.register(bus);
     }
 
-    public static Set<RegistryObject<? extends BlockEntityType<? extends TileEntityDrawers>>> getBlockEntityTypesWithRenderers() {
+    public static Set<RegistryObject<? extends BlockEntityType<? extends BlockEntityDrawers>>> getBlockEntityTypesWithRenderers() {
         return Collections.unmodifiableSet(BLOCK_ENTITY_TYPES_WITH_RENDERERS);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlockEntities.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlockEntities.java
@@ -19,28 +19,28 @@ import java.util.stream.Stream;
 public final class ModBlockEntities {
     public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITY_REGISTER = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITIES, StorageDrawers.MOD_ID);
 
-    private static final Set<RegistryObject<? extends BlockEntityType<? extends BlockEntityDrawers>>> BLOCK_ENTITY_TYPES_WITH_RENDERERS = new HashSet<>();
+    private static final Set<RegistryObject<? extends BlockEntityType<? extends TileEntityDrawers>>> BLOCK_ENTITY_TYPES_WITH_RENDERERS = new HashSet<>();
 
-    public static final RegistryObject<BlockEntityType<BlockEntityDrawersStandard>> STANDARD_DRAWERS_1 = registerDrawerBlockEntityType("standard_drawers_1", BlockEntityDrawersStandard.Slot1::new, BlockStandardDrawers.class, 1);
-    public static final RegistryObject<BlockEntityType<BlockEntityDrawersStandard>> STANDARD_DRAWERS_2 = registerDrawerBlockEntityType("standard_drawers_2", BlockEntityDrawersStandard.Slot2::new, BlockStandardDrawers.class, 2);
-    public static final RegistryObject<BlockEntityType<BlockEntityDrawersStandard>> STANDARD_DRAWERS_4 = registerDrawerBlockEntityType("standard_drawers_4", BlockEntityDrawersStandard.Slot4::new, BlockStandardDrawers.class, 4);
-    public static final RegistryObject<BlockEntityType<BlockEntityDrawersComp>> FRACTIONAL_DRAWERS_3 = registerDrawerBlockEntityType("fractional_drawers_3", BlockEntityDrawersComp.Slot3::new, BlockCompDrawers.class, 3);
-    public static final RegistryObject<BlockEntityType<BlockEntityController>> CONTROLLER = registerBlockEntityType("controller", BlockEntityController::new, BlockController.class);
-    public static final RegistryObject<BlockEntityType<BlockEntitySlave>> CONTROLLER_SLAVE = registerBlockEntityType("controller_slave", BlockEntitySlave::new, BlockSlave.class);
+    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_1 = registerDrawerBlockEntityType("standard_drawers_1", TileEntityDrawersStandard.Slot1::new, BlockStandardDrawers.class, 1);
+    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_2 = registerDrawerBlockEntityType("standard_drawers_2", TileEntityDrawersStandard.Slot2::new, BlockStandardDrawers.class, 2);
+    public static final RegistryObject<BlockEntityType<TileEntityDrawersStandard>> STANDARD_DRAWERS_4 = registerDrawerBlockEntityType("standard_drawers_4", TileEntityDrawersStandard.Slot4::new, BlockStandardDrawers.class, 4);
+    public static final RegistryObject<BlockEntityType<TileEntityDrawersComp>> FRACTIONAL_DRAWERS_3 = registerDrawerBlockEntityType("fractional_drawers_3", TileEntityDrawersComp.Slot3::new, BlockCompDrawers.class, 3);
+    public static final RegistryObject<BlockEntityType<TileEntityController>> CONTROLLER = registerBlockEntityType("controller", TileEntityController::new, BlockController.class);
+    public static final RegistryObject<BlockEntityType<TileEntitySlave>> CONTROLLER_SLAVE = registerBlockEntityType("controller_slave", TileEntitySlave::new, BlockSlave.class);
 
     private ModBlockEntities() {}
 
-    private static <BE extends BlockEntityDrawers, B extends BlockDrawers> RegistryObject<BlockEntityType<BE>> registerDrawerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Class<B> drawerBlockClass, int size) {
+    private static <BE extends TileEntityDrawers, B extends BlockDrawers> RegistryObject<BlockEntityType<BE>> registerDrawerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Class<B> drawerBlockClass, int size) {
         RegistryObject<BlockEntityType<BE>> ro = registerBlockEntityType(name, blockEntitySupplier, ModBlocks.getDrawersOfTypeAndSize(drawerBlockClass, size));
         BLOCK_ENTITY_TYPES_WITH_RENDERERS.add(ro);
         return ro;
     }
 
-    private static <BE extends BaseBlockEntity, B extends Block> RegistryObject<BlockEntityType<BE>> registerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Class<B> blockClass) {
+    private static <BE extends ChamTileEntity, B extends Block> RegistryObject<BlockEntityType<BE>> registerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Class<B> blockClass) {
         return registerBlockEntityType(name, blockEntitySupplier, ModBlocks.getBlocksOfType(blockClass));
     }
 
-    private static <BE extends BaseBlockEntity, B extends Block> RegistryObject<BlockEntityType<BE>> registerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Stream<B> blockStream) {
+    private static <BE extends ChamTileEntity, B extends Block> RegistryObject<BlockEntityType<BE>> registerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Stream<B> blockStream) {
         return BLOCK_ENTITY_REGISTER.register(name, () -> BlockEntityType.Builder.of(blockEntitySupplier, blockStream.toArray(Block[]::new)).build(null));
     }
 
@@ -48,7 +48,7 @@ public final class ModBlockEntities {
         BLOCK_ENTITY_REGISTER.register(bus);
     }
 
-    public static Set<RegistryObject<? extends BlockEntityType<? extends BlockEntityDrawers>>> getBlockEntityTypesWithRenderers() {
+    public static Set<RegistryObject<? extends BlockEntityType<? extends TileEntityDrawers>>> getBlockEntityTypesWithRenderers() {
         return Collections.unmodifiableSet(BLOCK_ENTITY_TYPES_WITH_RENDERERS);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlockEntities.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlockEntities.java
@@ -25,8 +25,8 @@ public final class ModBlockEntities {
     public static final RegistryObject<BlockEntityType<BlockEntityDrawersStandard>> STANDARD_DRAWERS_2 = registerDrawerBlockEntityType("standard_drawers_2", BlockEntityDrawersStandard.Slot2::new, BlockStandardDrawers.class, 2);
     public static final RegistryObject<BlockEntityType<BlockEntityDrawersStandard>> STANDARD_DRAWERS_4 = registerDrawerBlockEntityType("standard_drawers_4", BlockEntityDrawersStandard.Slot4::new, BlockStandardDrawers.class, 4);
     public static final RegistryObject<BlockEntityType<BlockEntityDrawersComp>> FRACTIONAL_DRAWERS_3 = registerDrawerBlockEntityType("fractional_drawers_3", BlockEntityDrawersComp.Slot3::new, BlockCompDrawers.class, 3);
-    public static final RegistryObject<BlockEntityType<BlockEntityController>> CONTROLLER = registerBlockEntityType("controller", BlockEntityController::new, BlockController.class);
-    public static final RegistryObject<BlockEntityType<BlockEntitySlave>> CONTROLLER_SLAVE = registerBlockEntityType("controller_slave", BlockEntitySlave::new, BlockSlave.class);
+    public static final RegistryObject<BlockEntityType<BlockEntityController>> CONTROLLER = registerBlockEntityType("controller", BlockEntityController::new, ModBlocks.getControllers());
+    public static final RegistryObject<BlockEntityType<BlockEntitySlave>> CONTROLLER_SLAVE = registerBlockEntityType("controller_slave", BlockEntitySlave::new, ModBlocks.getControllerSlaves());
 
     private ModBlockEntities() {}
 
@@ -34,10 +34,6 @@ public final class ModBlockEntities {
         RegistryObject<BlockEntityType<BE>> ro = registerBlockEntityType(name, blockEntitySupplier, ModBlocks.getDrawersOfTypeAndSize(drawerBlockClass, size));
         BLOCK_ENTITY_TYPES_WITH_RENDERERS.add(ro);
         return ro;
-    }
-
-    private static <BE extends BaseBlockEntity, B extends Block> RegistryObject<BlockEntityType<BE>> registerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Class<B> blockClass) {
-        return registerBlockEntityType(name, blockEntitySupplier, ModBlocks.getBlocksOfType(blockClass));
     }
 
     private static <BE extends BaseBlockEntity, B extends Block> RegistryObject<BlockEntityType<BE>> registerBlockEntityType(String name, BlockEntitySupplier<BE> blockEntitySupplier, Stream<B> blockStream) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlocks.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlocks.java
@@ -136,12 +136,12 @@ public final class ModBlocks
 
     public static <B extends BlockDrawers> Stream<B> getDrawersOfTypeAndSize(Class<B> drawerClass, int size) {
         return getBlocksOfType(drawerClass)
-                .filter(blockStandardDrawers -> blockStandardDrawers.getDrawerCount() == size);
+                .filter(blockDrawers -> blockDrawers.getDrawerCount() == size);
     }
 
     public static <B extends BlockDrawers> Stream<B> getDrawersOfTypeAndSizeAndDepth(Class<B> drawerClass, int size, boolean halfDepth) {
         return getDrawersOfTypeAndSize(drawerClass, size)
-                .filter(blockStandardDrawers -> blockStandardDrawers.isHalfDepth() == halfDepth);
+                .filter(blockDrawers -> blockDrawers.isHalfDepth() == halfDepth);
     }
 
     private static boolean predFalse (BlockState blockState, BlockGetter blockGetter, BlockPos blockPos) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlocks.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlocks.java
@@ -6,7 +6,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
-import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -21,54 +21,54 @@ public final class ModBlocks
     public static final DeferredRegister<Block> BLOCK_REGISTER = DeferredRegister.create(ForgeRegistries.BLOCKS, StorageDrawers.MOD_ID);
 
     public static final RegistryObject<BlockStandardDrawers>
-        OAK_FULL_DRAWERS_1 = registerDrawerBlock("oak_full_drawers_1", 1, false),
-        OAK_FULL_DRAWERS_2 = registerDrawerBlock("oak_full_drawers_2", 2, false),
-        OAK_FULL_DRAWERS_4 = registerDrawerBlock("oak_full_drawers_4", 4, false),
-        OAK_HALF_DRAWERS_1 = registerDrawerBlock("oak_half_drawers_1", 1, true),
-        OAK_HALF_DRAWERS_2 = registerDrawerBlock("oak_half_drawers_2", 2, true),
-        OAK_HALF_DRAWERS_4 = registerDrawerBlock("oak_half_drawers_4", 4, true),
-        SPRUCE_FULL_DRAWERS_1 = registerDrawerBlock("spruce_full_drawers_1", 1, false),
-        SPRUCE_FULL_DRAWERS_2 = registerDrawerBlock("spruce_full_drawers_2", 2, false),
-        SPRUCE_FULL_DRAWERS_4 = registerDrawerBlock("spruce_full_drawers_4", 4, false),
-        SPRUCE_HALF_DRAWERS_1 = registerDrawerBlock("spruce_half_drawers_1", 1, true),
-        SPRUCE_HALF_DRAWERS_2 = registerDrawerBlock("spruce_half_drawers_2", 2, true),
-        SPRUCE_HALF_DRAWERS_4 = registerDrawerBlock("spruce_half_drawers_4", 4, true),
-        BIRCH_FULL_DRAWERS_1 = registerDrawerBlock("birch_full_drawers_1", 1, false),
-        BIRCH_FULL_DRAWERS_2 = registerDrawerBlock("birch_full_drawers_2", 2, false),
-        BIRCH_FULL_DRAWERS_4 = registerDrawerBlock("birch_full_drawers_4", 4, false),
-        BIRCH_HALF_DRAWERS_1 = registerDrawerBlock("birch_half_drawers_1", 1, true),
-        BIRCH_HALF_DRAWERS_2 = registerDrawerBlock("birch_half_drawers_2", 2, true),
-        BIRCH_HALF_DRAWERS_4 = registerDrawerBlock("birch_half_drawers_4", 4, true),
-        JUNGLE_FULL_DRAWERS_1 = registerDrawerBlock("jungle_full_drawers_1", 1, false),
-        JUNGLE_FULL_DRAWERS_2 = registerDrawerBlock("jungle_full_drawers_2", 2, false),
-        JUNGLE_FULL_DRAWERS_4 = registerDrawerBlock("jungle_full_drawers_4", 4, false),
-        JUNGLE_HALF_DRAWERS_1 = registerDrawerBlock("jungle_half_drawers_1", 1, true),
-        JUNGLE_HALF_DRAWERS_2 = registerDrawerBlock("jungle_half_drawers_2", 2, true),
-        JUNGLE_HALF_DRAWERS_4 = registerDrawerBlock("jungle_half_drawers_4", 4, true),
-        ACACIA_FULL_DRAWERS_1 = registerDrawerBlock("acacia_full_drawers_1", 1, false),
-        ACACIA_FULL_DRAWERS_2 = registerDrawerBlock("acacia_full_drawers_2", 2, false),
-        ACACIA_FULL_DRAWERS_4 = registerDrawerBlock("acacia_full_drawers_4", 4, false),
-        ACACIA_HALF_DRAWERS_1 = registerDrawerBlock("acacia_half_drawers_1", 1, true),
-        ACACIA_HALF_DRAWERS_2 = registerDrawerBlock("acacia_half_drawers_2", 2, true),
-        ACACIA_HALF_DRAWERS_4 = registerDrawerBlock("acacia_half_drawers_4", 4, true),
-        DARK_OAK_FULL_DRAWERS_1 = registerDrawerBlock("dark_oak_full_drawers_1", 1, false),
-        DARK_OAK_FULL_DRAWERS_2 = registerDrawerBlock("dark_oak_full_drawers_2", 2, false),
-        DARK_OAK_FULL_DRAWERS_4 = registerDrawerBlock("dark_oak_full_drawers_4", 4, false),
-        DARK_OAK_HALF_DRAWERS_1 = registerDrawerBlock("dark_oak_half_drawers_1", 1, true),
-        DARK_OAK_HALF_DRAWERS_2 = registerDrawerBlock("dark_oak_half_drawers_2", 2, true),
-        DARK_OAK_HALF_DRAWERS_4 = registerDrawerBlock("dark_oak_half_drawers_4", 4, true),
-        CRIMSON_FULL_DRAWERS_1 = registerDrawerBlock("crimson_full_drawers_1", 1, false),
-        CRIMSON_FULL_DRAWERS_2 = registerDrawerBlock("crimson_full_drawers_2", 2, false),
-        CRIMSON_FULL_DRAWERS_4 = registerDrawerBlock("crimson_full_drawers_4", 4, false),
-        CRIMSON_HALF_DRAWERS_1 = registerDrawerBlock("crimson_half_drawers_1", 1, true),
-        CRIMSON_HALF_DRAWERS_2 = registerDrawerBlock("crimson_half_drawers_2", 2, true),
-        CRIMSON_HALF_DRAWERS_4 = registerDrawerBlock("crimson_half_drawers_4", 4, true),
-        WARPED_FULL_DRAWERS_1 = registerDrawerBlock("warped_full_drawers_1", 1, false),
-        WARPED_FULL_DRAWERS_2 = registerDrawerBlock("warped_full_drawers_2", 2, false),
-        WARPED_FULL_DRAWERS_4 = registerDrawerBlock("warped_full_drawers_4", 4, false),
-        WARPED_HALF_DRAWERS_1 = registerDrawerBlock("warped_half_drawers_1", 1, true),
-        WARPED_HALF_DRAWERS_2 = registerDrawerBlock("warped_half_drawers_2", 2, true),
-        WARPED_HALF_DRAWERS_4 = registerDrawerBlock("warped_half_drawers_4", 4, true);
+        OAK_FULL_DRAWERS_1 = registerWoodenDrawerBlock("oak_full_drawers_1", 1, false),
+        OAK_FULL_DRAWERS_2 = registerWoodenDrawerBlock("oak_full_drawers_2", 2, false),
+        OAK_FULL_DRAWERS_4 = registerWoodenDrawerBlock("oak_full_drawers_4", 4, false),
+        OAK_HALF_DRAWERS_1 = registerWoodenDrawerBlock("oak_half_drawers_1", 1, true),
+        OAK_HALF_DRAWERS_2 = registerWoodenDrawerBlock("oak_half_drawers_2", 2, true),
+        OAK_HALF_DRAWERS_4 = registerWoodenDrawerBlock("oak_half_drawers_4", 4, true),
+        SPRUCE_FULL_DRAWERS_1 = registerWoodenDrawerBlock("spruce_full_drawers_1", 1, false),
+        SPRUCE_FULL_DRAWERS_2 = registerWoodenDrawerBlock("spruce_full_drawers_2", 2, false),
+        SPRUCE_FULL_DRAWERS_4 = registerWoodenDrawerBlock("spruce_full_drawers_4", 4, false),
+        SPRUCE_HALF_DRAWERS_1 = registerWoodenDrawerBlock("spruce_half_drawers_1", 1, true),
+        SPRUCE_HALF_DRAWERS_2 = registerWoodenDrawerBlock("spruce_half_drawers_2", 2, true),
+        SPRUCE_HALF_DRAWERS_4 = registerWoodenDrawerBlock("spruce_half_drawers_4", 4, true),
+        BIRCH_FULL_DRAWERS_1 = registerWoodenDrawerBlock("birch_full_drawers_1", 1, false),
+        BIRCH_FULL_DRAWERS_2 = registerWoodenDrawerBlock("birch_full_drawers_2", 2, false),
+        BIRCH_FULL_DRAWERS_4 = registerWoodenDrawerBlock("birch_full_drawers_4", 4, false),
+        BIRCH_HALF_DRAWERS_1 = registerWoodenDrawerBlock("birch_half_drawers_1", 1, true),
+        BIRCH_HALF_DRAWERS_2 = registerWoodenDrawerBlock("birch_half_drawers_2", 2, true),
+        BIRCH_HALF_DRAWERS_4 = registerWoodenDrawerBlock("birch_half_drawers_4", 4, true),
+        JUNGLE_FULL_DRAWERS_1 = registerWoodenDrawerBlock("jungle_full_drawers_1", 1, false),
+        JUNGLE_FULL_DRAWERS_2 = registerWoodenDrawerBlock("jungle_full_drawers_2", 2, false),
+        JUNGLE_FULL_DRAWERS_4 = registerWoodenDrawerBlock("jungle_full_drawers_4", 4, false),
+        JUNGLE_HALF_DRAWERS_1 = registerWoodenDrawerBlock("jungle_half_drawers_1", 1, true),
+        JUNGLE_HALF_DRAWERS_2 = registerWoodenDrawerBlock("jungle_half_drawers_2", 2, true),
+        JUNGLE_HALF_DRAWERS_4 = registerWoodenDrawerBlock("jungle_half_drawers_4", 4, true),
+        ACACIA_FULL_DRAWERS_1 = registerWoodenDrawerBlock("acacia_full_drawers_1", 1, false),
+        ACACIA_FULL_DRAWERS_2 = registerWoodenDrawerBlock("acacia_full_drawers_2", 2, false),
+        ACACIA_FULL_DRAWERS_4 = registerWoodenDrawerBlock("acacia_full_drawers_4", 4, false),
+        ACACIA_HALF_DRAWERS_1 = registerWoodenDrawerBlock("acacia_half_drawers_1", 1, true),
+        ACACIA_HALF_DRAWERS_2 = registerWoodenDrawerBlock("acacia_half_drawers_2", 2, true),
+        ACACIA_HALF_DRAWERS_4 = registerWoodenDrawerBlock("acacia_half_drawers_4", 4, true),
+        DARK_OAK_FULL_DRAWERS_1 = registerWoodenDrawerBlock("dark_oak_full_drawers_1", 1, false),
+        DARK_OAK_FULL_DRAWERS_2 = registerWoodenDrawerBlock("dark_oak_full_drawers_2", 2, false),
+        DARK_OAK_FULL_DRAWERS_4 = registerWoodenDrawerBlock("dark_oak_full_drawers_4", 4, false),
+        DARK_OAK_HALF_DRAWERS_1 = registerWoodenDrawerBlock("dark_oak_half_drawers_1", 1, true),
+        DARK_OAK_HALF_DRAWERS_2 = registerWoodenDrawerBlock("dark_oak_half_drawers_2", 2, true),
+        DARK_OAK_HALF_DRAWERS_4 = registerWoodenDrawerBlock("dark_oak_half_drawers_4", 4, true),
+        CRIMSON_FULL_DRAWERS_1 = registerWoodenDrawerBlock("crimson_full_drawers_1", 1, false),
+        CRIMSON_FULL_DRAWERS_2 = registerWoodenDrawerBlock("crimson_full_drawers_2", 2, false),
+        CRIMSON_FULL_DRAWERS_4 = registerWoodenDrawerBlock("crimson_full_drawers_4", 4, false),
+        CRIMSON_HALF_DRAWERS_1 = registerWoodenDrawerBlock("crimson_half_drawers_1", 1, true),
+        CRIMSON_HALF_DRAWERS_2 = registerWoodenDrawerBlock("crimson_half_drawers_2", 2, true),
+        CRIMSON_HALF_DRAWERS_4 = registerWoodenDrawerBlock("crimson_half_drawers_4", 4, true),
+        WARPED_FULL_DRAWERS_1 = registerWoodenDrawerBlock("warped_full_drawers_1", 1, false),
+        WARPED_FULL_DRAWERS_2 = registerWoodenDrawerBlock("warped_full_drawers_2", 2, false),
+        WARPED_FULL_DRAWERS_4 = registerWoodenDrawerBlock("warped_full_drawers_4", 4, false),
+        WARPED_HALF_DRAWERS_1 = registerWoodenDrawerBlock("warped_half_drawers_1", 1, true),
+        WARPED_HALF_DRAWERS_2 = registerWoodenDrawerBlock("warped_half_drawers_2", 2, true),
+        WARPED_HALF_DRAWERS_4 = registerWoodenDrawerBlock("warped_half_drawers_4", 4, true);
 
     public static final RegistryObject<BlockCompDrawers> COMPACTING_DRAWERS_3 = registerCompactingDrawerBlock("compacting_drawers_3");
 
@@ -87,61 +87,72 @@ public final class ModBlocks
 
     private ModBlocks() {}
 
-    private static RegistryObject<BlockStandardDrawers> registerDrawerBlock(String name, int drawerCount, boolean halfDepth) {
-        return BLOCK_REGISTER.register(name, () -> new BlockStandardDrawers(drawerCount, halfDepth, BlockBehaviour.Properties.of(Material.WOOD)
-                .strength(3.0F, 5.0F)
-                .sound(SoundType.WOOD)
-                .isSuffocating(ModBlocks::predFalse)
-                .isRedstoneConductor(ModBlocks::predFalse)));
+    private static RegistryObject<BlockStandardDrawers> registerWoodenDrawerBlock(String name, int drawerCount, boolean halfDepth) {
+        return BLOCK_REGISTER.register(name, () -> new BlockStandardDrawers(drawerCount, halfDepth, getWoodenDrawerBlockProperties()));
     }
 
     private static RegistryObject<BlockCompDrawers> registerCompactingDrawerBlock(String name) {
-        return  BLOCK_REGISTER.register(name, () -> new BlockCompDrawers(BlockBehaviour.Properties.of(Material.STONE)
-                .sound(SoundType.STONE).strength(10f)
-                .isSuffocating(ModBlocks::predFalse)
-                .isRedstoneConductor(ModBlocks::predFalse)));
+        return BLOCK_REGISTER.register(name, () -> new BlockCompDrawers(getStoneDrawerBlockProperties()));
     }
 
     private static RegistryObject<BlockTrim> registerTrimBlock(String name) {
-        return BLOCK_REGISTER.register(name, () -> new BlockTrim(BlockBehaviour.Properties.of(Material.WOOD)
-                .sound(SoundType.WOOD).strength(5f)));
+        return BLOCK_REGISTER.register(name, () -> new BlockTrim(getWoodenBlockProperties()));
     }
 
     private static RegistryObject<BlockController> registerControllerBlock(String name) {
-        return  BLOCK_REGISTER.register(name, () -> new BlockController(BlockBehaviour.Properties.of(Material.WOOD)
-                .sound(SoundType.STONE).strength(5f)));
+        return BLOCK_REGISTER.register(name, () -> new BlockController(getStoneBlockProperties()));
     }
 
     private static RegistryObject<BlockSlave> registerControllerSlaveBlock(String name) {
-        return  BLOCK_REGISTER.register(name, () -> new BlockSlave(BlockBehaviour.Properties.of(Material.WOOD)
-                .sound(SoundType.STONE).strength(5f)));
+        return BLOCK_REGISTER.register(name, () -> new BlockSlave(getStoneBlockProperties()));
+    }
+
+    private static Properties getWoodenBlockProperties() {
+        return Properties.of(Material.WOOD).sound(SoundType.WOOD).strength(3f, 4f);
+    }
+
+    private static Properties getWoodenDrawerBlockProperties() {
+        return getWoodenBlockProperties().isSuffocating(ModBlocks::predFalse).isRedstoneConductor(ModBlocks::predFalse);
+    }
+
+    private static Properties getStoneBlockProperties() {
+        return Properties.of(Material.STONE).sound(SoundType.STONE).strength(4f, 5f);
+    }
+
+    private static Properties getStoneDrawerBlockProperties() {
+        return getStoneBlockProperties().isSuffocating(ModBlocks::predFalse).isRedstoneConductor(ModBlocks::predFalse);
     }
 
     public static void register(IEventBus bus) {
         BLOCK_REGISTER.register(bus);
     }
 
-    public static <B extends Block> Stream<B> getBlocksOfType(Class<B> blockClass) {
-        return BLOCK_REGISTER.getEntries()
-                .stream()
-                .filter(RegistryObject::isPresent)
-                .map(RegistryObject::get)
-                .filter(blockClass::isInstance)
-                .map(blockClass::cast);
+    private static <B extends Block> Stream<B> getBlocksOfType(Class<B> blockClass) {
+        return ForgeRegistries.BLOCKS.getValues().stream().filter(blockClass::isInstance).map(blockClass::cast);
     }
 
     public static Stream<BlockDrawers> getDrawers() {
         return getBlocksOfType(BlockDrawers.class);
     }
 
-    public static <B extends BlockDrawers> Stream<B> getDrawersOfTypeAndSize(Class<B> drawerClass, int size) {
-        return getBlocksOfType(drawerClass)
-                .filter(blockDrawers -> blockDrawers.getDrawerCount() == size);
+    public static Stream<BlockController> getControllers() {
+        return getBlocksOfType(BlockController.class);
     }
 
-    public static <B extends BlockDrawers> Stream<B> getDrawersOfTypeAndSizeAndDepth(Class<B> drawerClass, int size, boolean halfDepth) {
-        return getDrawersOfTypeAndSize(drawerClass, size)
-                .filter(blockDrawers -> blockDrawers.isHalfDepth() == halfDepth);
+    public static Stream<BlockSlave> getControllerSlaves() {
+        return getBlocksOfType(BlockSlave.class);
+    }
+
+    public static <BD extends BlockDrawers> Stream<BD> getDrawersOfType(Class<BD> drawerClass) {
+        return getBlocksOfType(drawerClass);
+    }
+
+    public static <BD extends BlockDrawers> Stream<BD> getDrawersOfTypeAndSize(Class<BD> drawerClass, int size) {
+        return getDrawersOfType(drawerClass).filter(blockDrawers -> blockDrawers.getDrawerCount() == size);
+    }
+
+    public static <BD extends BlockDrawers> Stream<BD> getDrawersOfTypeAndSizeAndDepth(Class<BD> drawerClass, int size, boolean halfDepth) {
+        return getDrawersOfTypeAndSize(drawerClass, size).filter(blockDrawers -> blockDrawers.isHalfDepth() == halfDepth);
     }
 
     private static boolean predFalse (BlockState blockState, BlockGetter blockGetter, BlockPos blockPos) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModItemGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModItemGroup.java
@@ -2,15 +2,14 @@ package com.jaquadro.minecraft.storagedrawers.core;
 
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ModItemGroup
 {
     public static final CreativeModeTab STORAGE_DRAWERS = (new CreativeModeTab("storagedrawers")
     {
         @Override
-        @Nonnull
+        @NotNull
         public ItemStack makeIcon () {
             return new ItemStack(ModBlocks.OAK_FULL_DRAWERS_2.get());
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/recipe/AddUpgradeRecipe.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/recipe/AddUpgradeRecipe.java
@@ -11,9 +11,9 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CustomRecipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,12 +24,13 @@ public class AddUpgradeRecipe extends CustomRecipe
     }
 
     @Override
-    public boolean matches(CraftingContainer inv, Level world) {
+    public boolean matches(@NotNull CraftingContainer inv, @NotNull Level world) {
         return findContext(inv) != null;
     }
 
     @Override
-    public ItemStack assemble(CraftingContainer inv) {
+    @NotNull
+    public ItemStack assemble(@NotNull CraftingContainer inv) {
         Context ctx = findContext(inv);
         if (ctx == null)
             return ItemStack.EMPTY;
@@ -67,7 +68,7 @@ public class AddUpgradeRecipe extends CustomRecipe
 
         ret.data = new UpgradeData(7) { //Hard coded to 7 as the only use is TileEntityDrawers$DrawerUpgradeData
             @Override
-            public boolean setUpgrade(int slot, @Nonnull ItemStack upgrade) { //Override this to bypass a lot of the complex logic
+            public boolean setUpgrade(int slot, @NotNull ItemStack upgrade) { //Override this to bypass a lot of the complex logic
                 if (upgrade.isEmpty())
                     return false;
                 upgrade = upgrade.copy();
@@ -97,6 +98,7 @@ public class AddUpgradeRecipe extends CustomRecipe
     }
 
     @Override
+    @NotNull
     public RecipeSerializer<?> getSerializer() {
         return StorageDrawers.UPGRADE_RECIPE_SERIALIZER.get();
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/recipe/TemplateRecipe.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/recipe/TemplateRecipe.java
@@ -12,7 +12,7 @@ import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.oredict.OreDictionary;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class TemplateRecipe implements IRecipe

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/DrawerOverlay.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/DrawerOverlay.java
@@ -2,7 +2,7 @@ package com.jaquadro.minecraft.storagedrawers.integration;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.*;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
 import net.minecraft.network.chat.Component;
@@ -21,7 +21,7 @@ public class DrawerOverlay {
     public boolean showStackRemainder = CommonConfig.INTEGRATION.wailaStackRemainder.get();
     public boolean respectQuantifyKey = CommonConfig.INTEGRATION.wailaRespectQuantifyKey.get();
 
-    public List<Component> getOverlay(final TileEntityDrawers tile) {
+    public List<Component> getOverlay(final BlockEntityDrawers tile) {
         final List<Component> result = new ArrayList<>();
 
         final IDrawerAttributes attr = tile.getCapability(CapabilityDrawerAttributes.DRAWER_ATTRIBUTES_CAPABILITY, null).orElse(EmptyDrawerAttributes.EMPTY);
@@ -32,7 +32,7 @@ public class DrawerOverlay {
         return result;
     }
 
-    private void addContent(final List<Component> result, final TileEntityDrawers tile, final IDrawerAttributes attr) {
+    private void addContent(final List<Component> result, final BlockEntityDrawers tile, final IDrawerAttributes attr) {
         if (!this.showContent || attr.isConcealed()) return;
         final boolean showCounts = !this.respectQuantifyKey || attr.isShowingQuantity();
 
@@ -74,7 +74,7 @@ public class DrawerOverlay {
 
     }
 
-    private void addStackLimit(List<Component> result, TileEntityDrawers tile, IDrawerAttributes attr) {
+    private void addStackLimit(List<Component> result, BlockEntityDrawers tile, IDrawerAttributes attr) {
         if (!this.showStackLimit) return;
 
         if (attr.isUnlimitedStorage() || tile.getDrawerAttributes().isUnlimitedVending())
@@ -86,7 +86,7 @@ public class DrawerOverlay {
         }
     }
 
-    private void addStatus(List<Component> result, TileEntityDrawers tile, IDrawerAttributes attr) {
+    private void addStatus(List<Component> result, BlockEntityDrawers tile, IDrawerAttributes attr) {
         if (!this.showStatus) return;
 
         List<MutableComponent> attribs = new ArrayList<>();

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/DrawerOverlay.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/DrawerOverlay.java
@@ -2,7 +2,7 @@ package com.jaquadro.minecraft.storagedrawers.integration;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.*;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
 import net.minecraft.network.chat.Component;
@@ -21,7 +21,7 @@ public class DrawerOverlay {
     public boolean showStackRemainder = CommonConfig.INTEGRATION.wailaStackRemainder.get();
     public boolean respectQuantifyKey = CommonConfig.INTEGRATION.wailaRespectQuantifyKey.get();
 
-    public List<Component> getOverlay(final BlockEntityDrawers tile) {
+    public List<Component> getOverlay(final TileEntityDrawers tile) {
         final List<Component> result = new ArrayList<>();
 
         final IDrawerAttributes attr = tile.getCapability(CapabilityDrawerAttributes.DRAWER_ATTRIBUTES_CAPABILITY, null).orElse(EmptyDrawerAttributes.EMPTY);
@@ -32,7 +32,7 @@ public class DrawerOverlay {
         return result;
     }
 
-    private void addContent(final List<Component> result, final BlockEntityDrawers tile, final IDrawerAttributes attr) {
+    private void addContent(final List<Component> result, final TileEntityDrawers tile, final IDrawerAttributes attr) {
         if (!this.showContent || attr.isConcealed()) return;
         final boolean showCounts = !this.respectQuantifyKey || attr.isShowingQuantity();
 
@@ -74,7 +74,7 @@ public class DrawerOverlay {
 
     }
 
-    private void addStackLimit(List<Component> result, BlockEntityDrawers tile, IDrawerAttributes attr) {
+    private void addStackLimit(List<Component> result, TileEntityDrawers tile, IDrawerAttributes attr) {
         if (!this.showStackLimit) return;
 
         if (attr.isUnlimitedStorage() || tile.getDrawerAttributes().isUnlimitedVending())
@@ -86,7 +86,7 @@ public class DrawerOverlay {
         }
     }
 
-    private void addStatus(List<Component> result, BlockEntityDrawers tile, IDrawerAttributes attr) {
+    private void addStatus(List<Component> result, TileEntityDrawers tile, IDrawerAttributes attr) {
         if (!this.showStatus) return;
 
         List<MutableComponent> attribs = new ArrayList<>();

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/TheOneProbe.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/TheOneProbe.java
@@ -1,14 +1,14 @@
 package com.jaquadro.minecraft.storagedrawers.integration;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
+import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
 import mcjty.theoneprobe.api.*;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.function.Function;
@@ -30,12 +30,10 @@ public class TheOneProbe implements Function<ITheOneProbe, Void> {
 
         @Override
         public void addProbeInfo(ProbeMode probeMode, IProbeInfo probe, Player player, Level world, BlockState blockState, IProbeHitData data) {
-            BlockEntity tile = world.getBlockEntity(data.getPos());
-            if (tile instanceof TileEntityDrawers) {
-                TileEntityDrawers drawers = (TileEntityDrawers) tile;
-
+            BlockEntityDrawers blockEntityDrawers = WorldUtils.getBlockEntity(world, data.getPos(), BlockEntityDrawers.class);
+            if (blockEntityDrawers != null) {
                 DrawerOverlay overlay = new DrawerOverlay();
-                for (Component component : overlay.getOverlay(drawers)) {
+                for (Component component : overlay.getOverlay(blockEntityDrawers)) {
                     probe.text(component);
                 }
             }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/TheOneProbe.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/TheOneProbe.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.integration;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
 import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
 import mcjty.theoneprobe.api.*;
@@ -30,10 +30,10 @@ public class TheOneProbe implements Function<ITheOneProbe, Void> {
 
         @Override
         public void addProbeInfo(ProbeMode probeMode, IProbeInfo probe, Player player, Level world, BlockState blockState, IProbeHitData data) {
-            BlockEntityDrawers blockEntityDrawers = WorldUtils.getBlockEntity(world, data.getPos(), BlockEntityDrawers.class);
-            if (blockEntityDrawers != null) {
+            TileEntityDrawers tileEntityDrawers = WorldUtils.getBlockEntity(world, data.getPos(), TileEntityDrawers.class);
+            if (tileEntityDrawers != null) {
                 DrawerOverlay overlay = new DrawerOverlay();
-                for (Component component : overlay.getOverlay(blockEntityDrawers)) {
+                for (Component component : overlay.getOverlay(tileEntityDrawers)) {
                     probe.text(component);
                 }
             }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/TheOneProbe.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/TheOneProbe.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.integration;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
 import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
 import mcjty.theoneprobe.api.*;
@@ -30,10 +30,10 @@ public class TheOneProbe implements Function<ITheOneProbe, Void> {
 
         @Override
         public void addProbeInfo(ProbeMode probeMode, IProbeInfo probe, Player player, Level world, BlockState blockState, IProbeHitData data) {
-            TileEntityDrawers tileEntityDrawers = WorldUtils.getBlockEntity(world, data.getPos(), TileEntityDrawers.class);
-            if (tileEntityDrawers != null) {
+            BlockEntityDrawers blockEntityDrawers = WorldUtils.getBlockEntity(world, data.getPos(), BlockEntityDrawers.class);
+            if (blockEntityDrawers != null) {
                 DrawerOverlay overlay = new DrawerOverlay();
-                for (Component component : overlay.getOverlay(tileEntityDrawers)) {
+                for (Component component : overlay.getOverlay(blockEntityDrawers)) {
                     probe.text(component);
                 }
             }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
@@ -2,7 +2,7 @@ package com.jaquadro.minecraft.storagedrawers.integration;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
 import mcp.mobius.waila.api.*;
 import mcp.mobius.waila.api.config.IPluginConfig;
@@ -41,14 +41,14 @@ public class Waila implements IWailaPlugin
 
         @Override
         public void appendTooltip (ITooltip currenttip, BlockAccessor accessor, IPluginConfig config) {
-            TileEntityDrawers tileEntityDrawers = (TileEntityDrawers) accessor.getBlockEntity();
+            BlockEntityDrawers blockEntityDrawers = (BlockEntityDrawers) accessor.getBlockEntity();
 
             DrawerOverlay overlay = new DrawerOverlay();
             overlay.showContent = config.get(StorageDrawers.rl("display.content"));
             overlay.showStackLimit = config.get(StorageDrawers.rl("display.stacklimit"));
             overlay.showStatus = config.get(StorageDrawers.rl("display.status"));
 
-            currenttip.addAll(overlay.getOverlay(tileEntityDrawers));
+            currenttip.addAll(overlay.getOverlay(blockEntityDrawers));
         }
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
@@ -2,15 +2,14 @@ package com.jaquadro.minecraft.storagedrawers.integration;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
 import mcp.mobius.waila.api.*;
 import mcp.mobius.waila.api.config.IPluginConfig;
 import mcp.mobius.waila.api.ui.IElement;
 import mcp.mobius.waila.impl.ui.ItemStackElement;
 import net.minecraft.world.item.ItemStack;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 @WailaPlugin(StorageDrawers.MOD_ID)
 public class Waila implements IWailaPlugin
@@ -35,21 +34,21 @@ public class Waila implements IWailaPlugin
     public static class WailaDrawer implements IComponentProvider
     {
         @Override
-        @Nonnull
+        @NotNull
         public IElement getIcon (BlockAccessor accessor, IPluginConfig config, IElement currentIcon) {
             return ItemStackElement.of(new ItemStack(accessor.getBlock()));
         }
 
         @Override
         public void appendTooltip (ITooltip currenttip, BlockAccessor accessor, IPluginConfig config) {
-            TileEntityDrawers tile = (TileEntityDrawers) accessor.getBlockEntity();
+            BlockEntityDrawers blockEntityDrawers = (BlockEntityDrawers) accessor.getBlockEntity();
 
             DrawerOverlay overlay = new DrawerOverlay();
             overlay.showContent = config.get(StorageDrawers.rl("display.content"));
             overlay.showStackLimit = config.get(StorageDrawers.rl("display.stacklimit"));
             overlay.showStatus = config.get(StorageDrawers.rl("display.status"));
 
-            currenttip.addAll(overlay.getOverlay(tile));
+            currenttip.addAll(overlay.getOverlay(blockEntityDrawers));
         }
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
@@ -2,7 +2,7 @@ package com.jaquadro.minecraft.storagedrawers.integration;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.config.ClientConfig;
 import mcp.mobius.waila.api.*;
 import mcp.mobius.waila.api.config.IPluginConfig;
@@ -41,14 +41,14 @@ public class Waila implements IWailaPlugin
 
         @Override
         public void appendTooltip (ITooltip currenttip, BlockAccessor accessor, IPluginConfig config) {
-            BlockEntityDrawers blockEntityDrawers = (BlockEntityDrawers) accessor.getBlockEntity();
+            TileEntityDrawers tileEntityDrawers = (TileEntityDrawers) accessor.getBlockEntity();
 
             DrawerOverlay overlay = new DrawerOverlay();
             overlay.showContent = config.get(StorageDrawers.rl("display.content"));
             overlay.showStackLimit = config.get(StorageDrawers.rl("display.stacklimit"));
             overlay.showStatus = config.get(StorageDrawers.rl("display.status"));
 
-            currenttip.addAll(overlay.getOverlay(blockEntityDrawers));
+            currenttip.addAll(overlay.getOverlay(tileEntityDrawers));
         }
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers.java
@@ -3,7 +3,7 @@ package com.jaquadro.minecraft.storagedrawers.inventory;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.client.renderer.StorageRenderItem;
 import com.jaquadro.minecraft.storagedrawers.item.ItemUpgrade;
 import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
@@ -51,18 +51,18 @@ public abstract class ContainerDrawers extends AbstractContainerMenu
         this(type, windowId, playerInv, getBlockEntity(playerInv, data.readBlockPos()));
     }
 
-    protected static TileEntityDrawers getBlockEntity(Inventory playerInv, BlockPos pos) {
+    protected static BlockEntityDrawers getBlockEntity(Inventory playerInv, BlockPos pos) {
         Level level = playerInv.player.getCommandSenderWorld();
-        TileEntityDrawers tileEntityDrawers = WorldUtils.getBlockEntity(level, pos, TileEntityDrawers.class);
-        if (tileEntityDrawers == null)
+        BlockEntityDrawers blockEntity = WorldUtils.getBlockEntity(level, pos, BlockEntityDrawers.class);
+        if (blockEntity == null)
             StorageDrawers.log.error("Expected a drawers tile entity at " + pos);
         else
-            return tileEntityDrawers;
+            return blockEntity;
 
         return null;
     }
 
-    public ContainerDrawers (@Nullable MenuType<?> type, int windowId, Inventory playerInventory, TileEntityDrawers tileEntity) {
+    public ContainerDrawers (@Nullable MenuType<?> type, int windowId, Inventory playerInventory, BlockEntityDrawers tileEntity) {
         super(type, windowId);
 
         int drawerCount = 0;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers.java
@@ -3,7 +3,7 @@ package com.jaquadro.minecraft.storagedrawers.inventory;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.client.renderer.StorageRenderItem;
 import com.jaquadro.minecraft.storagedrawers.item.ItemUpgrade;
 import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
@@ -51,18 +51,18 @@ public abstract class ContainerDrawers extends AbstractContainerMenu
         this(type, windowId, playerInv, getBlockEntity(playerInv, data.readBlockPos()));
     }
 
-    protected static BlockEntityDrawers getBlockEntity(Inventory playerInv, BlockPos pos) {
+    protected static TileEntityDrawers getBlockEntity(Inventory playerInv, BlockPos pos) {
         Level level = playerInv.player.getCommandSenderWorld();
-        BlockEntityDrawers blockEntity = WorldUtils.getBlockEntity(level, pos, BlockEntityDrawers.class);
-        if (blockEntity == null)
+        TileEntityDrawers tileEntityDrawers = WorldUtils.getBlockEntity(level, pos, TileEntityDrawers.class);
+        if (tileEntityDrawers == null)
             StorageDrawers.log.error("Expected a drawers tile entity at " + pos);
         else
-            return blockEntity;
+            return tileEntityDrawers;
 
         return null;
     }
 
-    public ContainerDrawers (@Nullable MenuType<?> type, int windowId, Inventory playerInventory, BlockEntityDrawers tileEntity) {
+    public ContainerDrawers (@Nullable MenuType<?> type, int windowId, Inventory playerInventory, TileEntityDrawers tileEntity) {
         super(type, windowId);
 
         int drawerCount = 0;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers1.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers1.java
@@ -1,6 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
@@ -15,8 +15,8 @@ public class ContainerDrawers1 extends ContainerDrawers
         super(ModContainers.DRAWER_CONTAINER_1.get(), windowId, playerInv, data);
     }
 
-    public ContainerDrawers1 (int windowId, Inventory playerInventory, BlockEntityDrawers blockEntityDrawers) {
-        super(ModContainers.DRAWER_CONTAINER_1.get(), windowId, playerInventory, blockEntityDrawers);
+    public ContainerDrawers1 (int windowId, Inventory playerInventory, TileEntityDrawers tileEntityDrawers) {
+        super(ModContainers.DRAWER_CONTAINER_1.get(), windowId, playerInventory, tileEntityDrawers);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers1.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers1.java
@@ -1,6 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
@@ -15,8 +15,8 @@ public class ContainerDrawers1 extends ContainerDrawers
         super(ModContainers.DRAWER_CONTAINER_1.get(), windowId, playerInv, data);
     }
 
-    public ContainerDrawers1 (int windowId, Inventory playerInventory, TileEntityDrawers tileEntityDrawers) {
-        super(ModContainers.DRAWER_CONTAINER_1.get(), windowId, playerInventory, tileEntityDrawers);
+    public ContainerDrawers1 (int windowId, Inventory playerInventory, BlockEntityDrawers blockEntityDrawers) {
+        super(ModContainers.DRAWER_CONTAINER_1.get(), windowId, playerInventory, blockEntityDrawers);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers1.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers1.java
@@ -1,9 +1,9 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
-import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Inventory;
 
 public class ContainerDrawers1 extends ContainerDrawers
 {
@@ -15,8 +15,8 @@ public class ContainerDrawers1 extends ContainerDrawers
         super(ModContainers.DRAWER_CONTAINER_1.get(), windowId, playerInv, data);
     }
 
-    public ContainerDrawers1 (int windowId, Inventory playerInventory, TileEntityDrawers tileEntity) {
-        super(ModContainers.DRAWER_CONTAINER_1.get(), windowId, playerInventory, tileEntity);
+    public ContainerDrawers1 (int windowId, Inventory playerInventory, BlockEntityDrawers blockEntityDrawers) {
+        super(ModContainers.DRAWER_CONTAINER_1.get(), windowId, playerInventory, blockEntityDrawers);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers2.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers2.java
@@ -1,6 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
@@ -15,8 +15,8 @@ public class ContainerDrawers2 extends ContainerDrawers
         super(ModContainers.DRAWER_CONTAINER_2.get(), windowId, playerInv, data);
     }
 
-    public ContainerDrawers2 (int windowId, Inventory playerInventory, BlockEntityDrawers blockEntityDrawers) {
-        super(ModContainers.DRAWER_CONTAINER_2.get(), windowId, playerInventory, blockEntityDrawers);
+    public ContainerDrawers2 (int windowId, Inventory playerInventory, TileEntityDrawers tileEntityDrawers) {
+        super(ModContainers.DRAWER_CONTAINER_2.get(), windowId, playerInventory, tileEntityDrawers);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers2.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers2.java
@@ -1,9 +1,9 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
-import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Inventory;
 
 public class ContainerDrawers2 extends ContainerDrawers
 {
@@ -15,8 +15,8 @@ public class ContainerDrawers2 extends ContainerDrawers
         super(ModContainers.DRAWER_CONTAINER_2.get(), windowId, playerInv, data);
     }
 
-    public ContainerDrawers2 (int windowId, Inventory playerInventory, TileEntityDrawers tileEntity) {
-        super(ModContainers.DRAWER_CONTAINER_2.get(), windowId, playerInventory, tileEntity);
+    public ContainerDrawers2 (int windowId, Inventory playerInventory, BlockEntityDrawers blockEntityDrawers) {
+        super(ModContainers.DRAWER_CONTAINER_2.get(), windowId, playerInventory, blockEntityDrawers);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers2.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers2.java
@@ -1,6 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
@@ -15,8 +15,8 @@ public class ContainerDrawers2 extends ContainerDrawers
         super(ModContainers.DRAWER_CONTAINER_2.get(), windowId, playerInv, data);
     }
 
-    public ContainerDrawers2 (int windowId, Inventory playerInventory, TileEntityDrawers tileEntityDrawers) {
-        super(ModContainers.DRAWER_CONTAINER_2.get(), windowId, playerInventory, tileEntityDrawers);
+    public ContainerDrawers2 (int windowId, Inventory playerInventory, BlockEntityDrawers blockEntityDrawers) {
+        super(ModContainers.DRAWER_CONTAINER_2.get(), windowId, playerInventory, blockEntityDrawers);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers4.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers4.java
@@ -1,6 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
@@ -15,8 +15,8 @@ public class ContainerDrawers4 extends ContainerDrawers
         super(ModContainers.DRAWER_CONTAINER_4.get(), windowId, playerInv, data);
     }
 
-    public ContainerDrawers4 (int windowId, Inventory playerInventory, TileEntityDrawers tileEntityDrawers) {
-        super(ModContainers.DRAWER_CONTAINER_4.get(), windowId, playerInventory, tileEntityDrawers);
+    public ContainerDrawers4 (int windowId, Inventory playerInventory, BlockEntityDrawers blockEntityDrawers) {
+        super(ModContainers.DRAWER_CONTAINER_4.get(), windowId, playerInventory, blockEntityDrawers);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers4.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers4.java
@@ -1,6 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
@@ -15,8 +15,8 @@ public class ContainerDrawers4 extends ContainerDrawers
         super(ModContainers.DRAWER_CONTAINER_4.get(), windowId, playerInv, data);
     }
 
-    public ContainerDrawers4 (int windowId, Inventory playerInventory, BlockEntityDrawers blockEntityDrawers) {
-        super(ModContainers.DRAWER_CONTAINER_4.get(), windowId, playerInventory, blockEntityDrawers);
+    public ContainerDrawers4 (int windowId, Inventory playerInventory, TileEntityDrawers tileEntityDrawers) {
+        super(ModContainers.DRAWER_CONTAINER_4.get(), windowId, playerInventory, tileEntityDrawers);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers4.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawers4.java
@@ -1,9 +1,9 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
-import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Inventory;
 
 public class ContainerDrawers4 extends ContainerDrawers
 {
@@ -15,8 +15,8 @@ public class ContainerDrawers4 extends ContainerDrawers
         super(ModContainers.DRAWER_CONTAINER_4.get(), windowId, playerInv, data);
     }
 
-    public ContainerDrawers4 (int windowId, Inventory playerInventory, TileEntityDrawers tileEntity) {
-        super(ModContainers.DRAWER_CONTAINER_4.get(), windowId, playerInventory, tileEntity);
+    public ContainerDrawers4 (int windowId, Inventory playerInventory, BlockEntityDrawers blockEntityDrawers) {
+        super(ModContainers.DRAWER_CONTAINER_4.get(), windowId, playerInventory, blockEntityDrawers);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawersComp.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawersComp.java
@@ -1,9 +1,9 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
-import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Inventory;
 
 public class ContainerDrawersComp extends ContainerDrawers
 {
@@ -15,7 +15,7 @@ public class ContainerDrawersComp extends ContainerDrawers
         super(ModContainers.DRAWER_CONTAINER_COMP.get(), windowId, playerInventory, packet);
     }
 
-    public ContainerDrawersComp (int windowId, Inventory playerInventory, TileEntityDrawers tile) {
+    public ContainerDrawersComp (int windowId, Inventory playerInventory, BlockEntityDrawers tile) {
         super(ModContainers.DRAWER_CONTAINER_COMP.get(), windowId, playerInventory, tile);
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawersComp.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawersComp.java
@@ -1,6 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
@@ -15,7 +15,7 @@ public class ContainerDrawersComp extends ContainerDrawers
         super(ModContainers.DRAWER_CONTAINER_COMP.get(), windowId, playerInventory, packet);
     }
 
-    public ContainerDrawersComp (int windowId, Inventory playerInventory, TileEntityDrawers tile) {
+    public ContainerDrawersComp (int windowId, Inventory playerInventory, BlockEntityDrawers tile) {
         super(ModContainers.DRAWER_CONTAINER_COMP.get(), windowId, playerInventory, tile);
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawersComp.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerDrawersComp.java
@@ -1,6 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.core.ModContainers;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
@@ -15,7 +15,7 @@ public class ContainerDrawersComp extends ContainerDrawers
         super(ModContainers.DRAWER_CONTAINER_COMP.get(), windowId, playerInventory, packet);
     }
 
-    public ContainerDrawersComp (int windowId, Inventory playerInventory, BlockEntityDrawers tile) {
+    public ContainerDrawersComp (int windowId, Inventory playerInventory, TileEntityDrawers tile) {
         super(ModContainers.DRAWER_CONTAINER_COMP.get(), windowId, playerInventory, tile);
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/DrawerInventoryHelper.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/DrawerInventoryHelper.java
@@ -2,9 +2,9 @@ package com.jaquadro.minecraft.storagedrawers.inventory;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 
 import java.util.Random;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/DrawerScreen.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/DrawerScreen.java
@@ -2,16 +2,17 @@ package com.jaquadro.minecraft.storagedrawers.inventory;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.client.renderer.StorageRenderItem;
-import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.resources.language.I18n;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -67,14 +68,14 @@ public class DrawerScreen extends AbstractContainerScreen<ContainerDrawers>
     protected void init () {
         super.init();
 
-        if (storageItemRender == null) {
+        if (storageItemRender == null && minecraft != null) {
             ItemRenderer defaultRenderItem = minecraft.getItemRenderer();
             storageItemRender = new StorageRenderItem(minecraft.getTextureManager(), defaultRenderItem.getItemModelShaper().getModelManager(), minecraft.getItemColors());
         }
     }
 
     @Override
-    public void render (PoseStack stack, int p_render_1_, int p_render_2_, float p_render_3_) {
+    public void render (@NotNull PoseStack stack, int p_render_1_, int p_render_2_, float p_render_3_) {
         ItemRenderer ri = setItemRender(storageItemRender);
         menu.activeRenderItem = storageItemRender;
 
@@ -89,14 +90,14 @@ public class DrawerScreen extends AbstractContainerScreen<ContainerDrawers>
     }
 
     @Override
-    protected void renderLabels (PoseStack stack, int mouseX, int mouseY) {
+    protected void renderLabels (@NotNull PoseStack stack, int mouseX, int mouseY) {
         this.font.draw(stack, this.title.getString(), 8.0F, 6.0F, 4210752);
         this.font.draw(stack, I18n.get("container.storagedrawers.upgrades"), 8, 75, 4210752);
         this.font.draw(stack, this.inventory.getDisplayName().getString(), 8, this.imageHeight - 96 + 2, 4210752);
     }
 
     @Override
-    protected void renderBg (PoseStack stack, float partialTicks, int mouseX, int mouseY) {
+    protected void renderBg (@NotNull PoseStack stack, float partialTicks, int mouseX, int mouseY) {
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.setShaderTexture(0, background);
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/DrawerScreen.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/DrawerScreen.java
@@ -4,6 +4,7 @@ import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.client.renderer.StorageRenderItem;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.resources.language.I18n;
@@ -112,7 +113,7 @@ public class DrawerScreen extends AbstractContainerScreen<ContainerDrawers>
 
         List<Slot> upgradeSlots = menu.getUpgradeSlots();
         for (Slot slot : upgradeSlots) {
-            if (slot instanceof SlotUpgrade && !((SlotUpgrade) slot).canTakeStack())
+            if (slot instanceof SlotUpgrade && !((SlotUpgrade) slot).canTakeStack(Minecraft.getInstance().player))
                 blit(stack, guiX + slot.x, guiY + slot.y, smDisabledX, smDisabledY, 16, 16);
         }
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/InventoryUpgrade.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/InventoryUpgrade.java
@@ -1,21 +1,21 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-
-import javax.annotation.Nonnull;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
 
 public class InventoryUpgrade implements Container
 {
     private static final int upgradeCapacity = 7;
 
-    private TileEntityDrawers tile;
+    private final BlockEntityDrawers blockEntityDrawers;
 
-    public InventoryUpgrade (TileEntityDrawers tileEntity) {
-        tile = tileEntity;
+    public InventoryUpgrade (BlockEntityDrawers blockEntityDrawers) {
+        this.blockEntityDrawers = blockEntityDrawers;
     }
 
     @Override
@@ -26,7 +26,7 @@ public class InventoryUpgrade implements Container
     @Override
     public boolean isEmpty () {
         for (int i = 0; i < upgradeCapacity; i++) {
-            if (!tile.upgrades().getUpgrade(i).isEmpty())
+            if (!blockEntityDrawers.upgrades().getUpgrade(i).isEmpty())
                 return false;
         }
 
@@ -34,30 +34,30 @@ public class InventoryUpgrade implements Container
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public ItemStack getItem (int slot) {
-        return tile.upgrades().getUpgrade(slot);
+        return blockEntityDrawers.upgrades().getUpgrade(slot);
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public ItemStack removeItem (int slot, int count) {
-        ItemStack stack = tile.upgrades().getUpgrade(slot);
+        ItemStack stack = blockEntityDrawers.upgrades().getUpgrade(slot);
         if (count > 0)
-            tile.upgrades().setUpgrade(slot, ItemStack.EMPTY);
+            blockEntityDrawers.upgrades().setUpgrade(slot, ItemStack.EMPTY);
 
         return stack;
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public ItemStack removeItemNoUpdate (int slot) {
         return ItemStack.EMPTY;
     }
 
     @Override
-    public void setItem (int slot, @Nonnull ItemStack item) {
-        tile.upgrades().setUpgrade(slot, item);
+    public void setItem (int slot, @NotNull ItemStack item) {
+        blockEntityDrawers.upgrades().setUpgrade(slot, item);
     }
 
     @Override
@@ -67,29 +67,26 @@ public class InventoryUpgrade implements Container
 
     @Override
     public void setChanged () {
-        tile.setChanged();
+        blockEntityDrawers.setChanged();
     }
 
     @Override
-    public boolean stillValid (Player player) {
-        BlockPos pos = tile.getBlockPos();
-        if (tile.getLevel() == null || tile.getLevel().getBlockEntity(pos) != tile)
+    public boolean stillValid (@NotNull Player player) {
+        BlockPos pos = blockEntityDrawers.getBlockPos();
+        if (blockEntityDrawers.getLevel() == null || blockEntityDrawers.getLevel().getBlockEntity(pos) != blockEntityDrawers)
             return false;
-        if (player.distanceToSqr(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5) > 64.0)
-            return false;
-
-        return true;
+        return !(player.distanceToSqr(Vec3.atCenterOf(pos)) > 64.0);
     }
 
     @Override
-    public void startOpen (Player player) { }
+    public void startOpen (@NotNull Player player) { }
 
     @Override
-    public void stopOpen (Player player) { }
+    public void stopOpen (@NotNull Player player) { }
 
     @Override
-    public boolean canPlaceItem (int slot, @Nonnull ItemStack item) {
-        return tile.upgrades().canAddUpgrade(item);
+    public boolean canPlaceItem (int slot, @NotNull ItemStack item) {
+        return blockEntityDrawers.upgrades().canAddUpgrade(item);
     }
 
     @Override
@@ -97,11 +94,11 @@ public class InventoryUpgrade implements Container
 
     }
 
-    public boolean canAddUpgrade (@Nonnull ItemStack item) {
-        return tile.upgrades().canAddUpgrade(item);
+    public boolean canAddUpgrade (@NotNull ItemStack item) {
+        return blockEntityDrawers.upgrades().canAddUpgrade(item);
     }
 
     public boolean canRemoveStorageUpgrade (int slot) {
-        return tile.upgrades().canRemoveUpgrade(slot);
+        return blockEntityDrawers.upgrades().canRemoveUpgrade(slot);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/InventoryUpgrade.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/InventoryUpgrade.java
@@ -1,6 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
@@ -12,10 +12,10 @@ public class InventoryUpgrade implements Container
 {
     private static final int upgradeCapacity = 7;
 
-    private final BlockEntityDrawers blockEntityDrawers;
+    private final TileEntityDrawers tileEntityDrawers;
 
-    public InventoryUpgrade (BlockEntityDrawers blockEntityDrawers) {
-        this.blockEntityDrawers = blockEntityDrawers;
+    public InventoryUpgrade (TileEntityDrawers tileEntityDrawers) {
+        this.tileEntityDrawers = tileEntityDrawers;
     }
 
     @Override
@@ -26,7 +26,7 @@ public class InventoryUpgrade implements Container
     @Override
     public boolean isEmpty () {
         for (int i = 0; i < upgradeCapacity; i++) {
-            if (!blockEntityDrawers.upgrades().getUpgrade(i).isEmpty())
+            if (!tileEntityDrawers.upgrades().getUpgrade(i).isEmpty())
                 return false;
         }
 
@@ -36,15 +36,15 @@ public class InventoryUpgrade implements Container
     @Override
     @NotNull
     public ItemStack getItem (int slot) {
-        return blockEntityDrawers.upgrades().getUpgrade(slot);
+        return tileEntityDrawers.upgrades().getUpgrade(slot);
     }
 
     @Override
     @NotNull
     public ItemStack removeItem (int slot, int count) {
-        ItemStack stack = blockEntityDrawers.upgrades().getUpgrade(slot);
+        ItemStack stack = tileEntityDrawers.upgrades().getUpgrade(slot);
         if (count > 0)
-            blockEntityDrawers.upgrades().setUpgrade(slot, ItemStack.EMPTY);
+            tileEntityDrawers.upgrades().setUpgrade(slot, ItemStack.EMPTY);
 
         return stack;
     }
@@ -57,7 +57,7 @@ public class InventoryUpgrade implements Container
 
     @Override
     public void setItem (int slot, @NotNull ItemStack item) {
-        blockEntityDrawers.upgrades().setUpgrade(slot, item);
+        tileEntityDrawers.upgrades().setUpgrade(slot, item);
     }
 
     @Override
@@ -67,13 +67,13 @@ public class InventoryUpgrade implements Container
 
     @Override
     public void setChanged () {
-        blockEntityDrawers.setChanged();
+        tileEntityDrawers.setChanged();
     }
 
     @Override
     public boolean stillValid (@NotNull Player player) {
-        BlockPos pos = blockEntityDrawers.getBlockPos();
-        if (blockEntityDrawers.getLevel() == null || blockEntityDrawers.getLevel().getBlockEntity(pos) != blockEntityDrawers)
+        BlockPos pos = tileEntityDrawers.getBlockPos();
+        if (tileEntityDrawers.getLevel() == null || tileEntityDrawers.getLevel().getBlockEntity(pos) != tileEntityDrawers)
             return false;
         return !(player.distanceToSqr(Vec3.atCenterOf(pos)) > 64.0);
     }
@@ -86,7 +86,7 @@ public class InventoryUpgrade implements Container
 
     @Override
     public boolean canPlaceItem (int slot, @NotNull ItemStack item) {
-        return blockEntityDrawers.upgrades().canAddUpgrade(item);
+        return tileEntityDrawers.upgrades().canAddUpgrade(item);
     }
 
     @Override
@@ -95,10 +95,10 @@ public class InventoryUpgrade implements Container
     }
 
     public boolean canAddUpgrade (@NotNull ItemStack item) {
-        return blockEntityDrawers.upgrades().canAddUpgrade(item);
+        return tileEntityDrawers.upgrades().canAddUpgrade(item);
     }
 
     public boolean canRemoveStorageUpgrade (int slot) {
-        return blockEntityDrawers.upgrades().canRemoveUpgrade(slot);
+        return tileEntityDrawers.upgrades().canRemoveUpgrade(slot);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/InventoryUpgrade.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/InventoryUpgrade.java
@@ -1,6 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
@@ -12,10 +12,10 @@ public class InventoryUpgrade implements Container
 {
     private static final int upgradeCapacity = 7;
 
-    private final TileEntityDrawers tileEntityDrawers;
+    private final BlockEntityDrawers blockEntityDrawers;
 
-    public InventoryUpgrade (TileEntityDrawers tileEntityDrawers) {
-        this.tileEntityDrawers = tileEntityDrawers;
+    public InventoryUpgrade (BlockEntityDrawers blockEntityDrawers) {
+        this.blockEntityDrawers = blockEntityDrawers;
     }
 
     @Override
@@ -26,7 +26,7 @@ public class InventoryUpgrade implements Container
     @Override
     public boolean isEmpty () {
         for (int i = 0; i < upgradeCapacity; i++) {
-            if (!tileEntityDrawers.upgrades().getUpgrade(i).isEmpty())
+            if (!blockEntityDrawers.upgrades().getUpgrade(i).isEmpty())
                 return false;
         }
 
@@ -36,15 +36,15 @@ public class InventoryUpgrade implements Container
     @Override
     @NotNull
     public ItemStack getItem (int slot) {
-        return tileEntityDrawers.upgrades().getUpgrade(slot);
+        return blockEntityDrawers.upgrades().getUpgrade(slot);
     }
 
     @Override
     @NotNull
     public ItemStack removeItem (int slot, int count) {
-        ItemStack stack = tileEntityDrawers.upgrades().getUpgrade(slot);
+        ItemStack stack = blockEntityDrawers.upgrades().getUpgrade(slot);
         if (count > 0)
-            tileEntityDrawers.upgrades().setUpgrade(slot, ItemStack.EMPTY);
+            blockEntityDrawers.upgrades().setUpgrade(slot, ItemStack.EMPTY);
 
         return stack;
     }
@@ -57,7 +57,7 @@ public class InventoryUpgrade implements Container
 
     @Override
     public void setItem (int slot, @NotNull ItemStack item) {
-        tileEntityDrawers.upgrades().setUpgrade(slot, item);
+        blockEntityDrawers.upgrades().setUpgrade(slot, item);
     }
 
     @Override
@@ -67,13 +67,13 @@ public class InventoryUpgrade implements Container
 
     @Override
     public void setChanged () {
-        tileEntityDrawers.setChanged();
+        blockEntityDrawers.setChanged();
     }
 
     @Override
     public boolean stillValid (@NotNull Player player) {
-        BlockPos pos = tileEntityDrawers.getBlockPos();
-        if (tileEntityDrawers.getLevel() == null || tileEntityDrawers.getLevel().getBlockEntity(pos) != tileEntityDrawers)
+        BlockPos pos = blockEntityDrawers.getBlockPos();
+        if (blockEntityDrawers.getLevel() == null || blockEntityDrawers.getLevel().getBlockEntity(pos) != blockEntityDrawers)
             return false;
         return !(player.distanceToSqr(Vec3.atCenterOf(pos)) > 64.0);
     }
@@ -86,7 +86,7 @@ public class InventoryUpgrade implements Container
 
     @Override
     public boolean canPlaceItem (int slot, @NotNull ItemStack item) {
-        return tileEntityDrawers.upgrades().canAddUpgrade(item);
+        return blockEntityDrawers.upgrades().canAddUpgrade(item);
     }
 
     @Override
@@ -95,10 +95,10 @@ public class InventoryUpgrade implements Container
     }
 
     public boolean canAddUpgrade (@NotNull ItemStack item) {
-        return tileEntityDrawers.upgrades().canAddUpgrade(item);
+        return blockEntityDrawers.upgrades().canAddUpgrade(item);
     }
 
     public boolean canRemoveStorageUpgrade (int slot) {
-        return tileEntityDrawers.upgrades().canRemoveUpgrade(slot);
+        return blockEntityDrawers.upgrades().canRemoveUpgrade(slot);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ItemStackHelper.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ItemStackHelper.java
@@ -1,10 +1,9 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ItemStackHelper
 {
@@ -14,7 +13,7 @@ public class ItemStackHelper
     //private static Field stackTagCompoundField;
     //private static Field capabilitiesField;
 
-    public static Item getTrueItem (@Nonnull ItemStack stack) {
+    public static Item getTrueItem (@NotNull ItemStack stack) {
         //if (!initialized)
             return stack.getItem();
 
@@ -25,8 +24,8 @@ public class ItemStackHelper
         }*/
     }
 
-    @Nonnull
-    public static ItemStack getItemPrototype (@Nonnull ItemStack stack) {
+    @NotNull
+    public static ItemStack getItemPrototype (@NotNull ItemStack stack) {
         //if (!initialized)
             return stack.copy();
 
@@ -45,8 +44,8 @@ public class ItemStackHelper
         }*/
     }
 
-    @Nonnull
-    public static ItemStack encodeItemStack (@Nonnull ItemStack stack) {
+    @NotNull
+    public static ItemStack encodeItemStack (@NotNull ItemStack stack) {
         if (!stack.isEmpty())
             return stack;
 
@@ -65,7 +64,7 @@ public class ItemStackHelper
         return proto;
     }
 
-    public static ItemStack encodeItemStack (@Nonnull ItemStack proto, int count) {
+    public static ItemStack encodeItemStack (@NotNull ItemStack proto, int count) {
         if (!proto.isEmpty() && count > 0 && count < 128) {
             ItemStack stack = proto.copy();
             stack.setCount(count);
@@ -88,20 +87,20 @@ public class ItemStackHelper
         return proto.copy();
     }
 
-    public static ItemStack decodeItemStack (@Nonnull ItemStack stack) {
+    public static ItemStack decodeItemStack (@NotNull ItemStack stack) {
         int count = ItemStackHelper.decodedCount(stack);
         ItemStack decode = ItemStackHelper.stripDecoding(stack);
         decode.setCount(count);
         return decode;
     }
 
-    public static ItemStack decodeItemStackPrototype (@Nonnull ItemStack stack) {
+    public static ItemStack decodeItemStackPrototype (@NotNull ItemStack stack) {
         ItemStack decode = ItemStackHelper.stripDecoding(stack);
         decode.setCount(1);
         return decode;
     }
 
-    public static int decodedCount (@Nonnull ItemStack stack) {
+    public static int decodedCount (@NotNull ItemStack stack) {
         CompoundTag tag = stack.getTag();
         if (tag != null && tag.contains("__storagedrawers_count"))
             return tag.getInt("__storagedrawers_count");
@@ -109,7 +108,7 @@ public class ItemStackHelper
         return stack.getCount();
     }
 
-    public static ItemStack stripDecoding (@Nonnull ItemStack stack) {
+    public static ItemStack stripDecoding (@NotNull ItemStack stack) {
         ItemStack decode = stack.copy();
         CompoundTag tag = decode.getTag();
 
@@ -124,7 +123,7 @@ public class ItemStackHelper
         return decode;
     }
 
-    public static boolean isStackEncoded (@Nonnull ItemStack stack) {
+    public static boolean isStackEncoded (@NotNull ItemStack stack) {
         CompoundTag tag = stack.getTag();
         if (tag == null)
             return false;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/SlotDrawer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/SlotDrawer.java
@@ -2,21 +2,20 @@ package com.jaquadro.minecraft.storagedrawers.inventory;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
-import net.minecraft.world.entity.player.Player;
+import net.minecraft.core.Direction;
 import net.minecraft.world.Container;
-import net.minecraft.world.WorldlyContainer;
 import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.WorldlyContainer;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.core.Direction;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class SlotDrawer extends Slot
 {
-    private static Container emptyInventory = new EmptyInventory();
-    private ContainerDrawers container;
+    private static final Container emptyInventory = new EmptyInventory();
+    private final ContainerDrawers container;
     private final IDrawerGroup group;
     private final IDrawer drawer;
 
@@ -28,12 +27,12 @@ public class SlotDrawer extends Slot
     }
 
     @Override
-    public boolean mayPlace (@Nonnull ItemStack stack) {
+    public boolean mayPlace (@NotNull ItemStack stack) {
         return !stack.isEmpty() && drawer.canItemBeStored(stack);
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public ItemStack getItem () {
         ItemStack stack = ItemStackHelper.encodeItemStack(drawer.getStoredItemPrototype(), drawer.getStoredItemCount());
         container.setLastAccessedItem(stack);
@@ -41,29 +40,29 @@ public class SlotDrawer extends Slot
     }
 
     @Override
-    public void set (@Nonnull ItemStack stack) {
+    public void set (@NotNull ItemStack stack) {
         IDrawer target = drawer.setStoredItem(stack);
         stack = ItemStackHelper.decodeItemStack(stack);
         target.setStoredItemCount(stack.getCount());
     }
 
     @Override
-    public void onQuickCraft (@Nonnull ItemStack p_75220_1_, @Nonnull ItemStack p_75220_2_) {
+    public void onQuickCraft (@NotNull ItemStack p_75220_1_, @NotNull ItemStack p_75220_2_) {
 
     }
 
     @Override
-    public int getMaxStackSize (@Nonnull ItemStack stack) {
+    public int getMaxStackSize (@NotNull ItemStack stack) {
         return Math.min(stack.getMaxStackSize(), drawer.getRemainingCapacity());
     }
 
     @Override
-    public boolean mayPickup (Player playerIn) {
+    public boolean mayPickup (@NotNull Player playerIn) {
         return false;
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public ItemStack remove (int amount) {
         int withdraw = Math.min(amount, drawer.getStoredItemCount());
         drawer.setStoredItemCount(withdraw);
@@ -78,7 +77,7 @@ public class SlotDrawer extends Slot
     }
 
     @Override
-    public boolean isSameInventory (Slot other) {
+    public boolean isSameInventory (@NotNull Slot other) {
         return other instanceof SlotDrawer && ((SlotDrawer) other).getDrawerGroup() == group;
     }
 
@@ -87,15 +86,15 @@ public class SlotDrawer extends Slot
             super(0);
         }
 
-        public int[] getSlotsForFace(Direction side) {
+        public int[] getSlotsForFace(@NotNull Direction side) {
             return new int[0];
         }
 
-        public boolean canPlaceItemThroughFace(int index, ItemStack itemStackIn, @Nullable Direction direction) {
+        public boolean canPlaceItemThroughFace(int index, @NotNull ItemStack itemStackIn, @Nullable Direction direction) {
             return false;
         }
 
-        public boolean canTakeItemThroughFace(int index, ItemStack stack, Direction direction) {
+        public boolean canTakeItemThroughFace(int index, @NotNull ItemStack stack, @NotNull Direction direction) {
             return false;
         }
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/SlotStorage.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/SlotStorage.java
@@ -1,8 +1,9 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.Slot;
+import org.jetbrains.annotations.NotNull;
 
 public class SlotStorage extends Slot
 {
@@ -11,7 +12,7 @@ public class SlotStorage extends Slot
     }
 
     @Override
-    public boolean mayPickup (Player player) {
+    public boolean mayPickup (@NotNull Player player) {
         return false;
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/SlotUpgrade.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/SlotUpgrade.java
@@ -3,12 +3,11 @@ package com.jaquadro.minecraft.storagedrawers.inventory;
 import com.jaquadro.minecraft.storagedrawers.core.ModItems;
 import com.jaquadro.minecraft.storagedrawers.item.EnumUpgradeStorage;
 import com.jaquadro.minecraft.storagedrawers.item.ItemUpgradeStorage;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class SlotUpgrade extends Slot
 {
@@ -17,7 +16,7 @@ public class SlotUpgrade extends Slot
     }
 
     @Override
-    public boolean mayPlace(@Nonnull ItemStack stack) {
+    public boolean mayPlace(@NotNull ItemStack stack) {
         if (stack.isEmpty())
             return false;
 
@@ -28,7 +27,7 @@ public class SlotUpgrade extends Slot
     }
 
     @Override
-    public boolean mayPickup (Player player) {
+    public boolean mayPickup (@NotNull Player player) {
         if (container instanceof InventoryUpgrade) {
             ItemStack stack = getItem();
             if (stack.getItem() instanceof ItemUpgradeStorage) {
@@ -36,9 +35,8 @@ public class SlotUpgrade extends Slot
                 return ((InventoryUpgrade) container).canRemoveStorageUpgrade(getSlotIndex());
             }
 
-            if (player != null && !player.isCreative()) {
-                if (stack.getItem() == ModItems.CREATIVE_STORAGE_UPGRADE.get() || stack.getItem() == ModItems.CREATIVE_VENDING_UPGRADE.get())
-                    return false;
+            if (!player.isCreative()) {
+                return stack.getItem() != ModItems.CREATIVE_STORAGE_UPGRADE.get() && stack.getItem() != ModItems.CREATIVE_VENDING_UPGRADE.get();
             }
         }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/SlotUpgrade.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/SlotUpgrade.java
@@ -1,13 +1,13 @@
 package com.jaquadro.minecraft.storagedrawers.inventory;
 
 import com.jaquadro.minecraft.storagedrawers.core.ModItems;
-import com.jaquadro.minecraft.storagedrawers.item.EnumUpgradeStorage;
 import com.jaquadro.minecraft.storagedrawers.item.ItemUpgradeStorage;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class SlotUpgrade extends Slot
 {
@@ -28,22 +28,25 @@ public class SlotUpgrade extends Slot
 
     @Override
     public boolean mayPickup (@NotNull Player player) {
+        return canTakeStack(player);
+    }
+
+    public boolean canTakeStack () {
+        return canTakeStack(null);
+    }
+
+    public boolean canTakeStack (@Nullable Player player) {
         if (container instanceof InventoryUpgrade) {
             ItemStack stack = getItem();
             if (stack.getItem() instanceof ItemUpgradeStorage) {
-                EnumUpgradeStorage upgrade = ((ItemUpgradeStorage)stack.getItem()).level;
                 return ((InventoryUpgrade) container).canRemoveStorageUpgrade(getSlotIndex());
             }
 
-            if (!player.isCreative()) {
+            if (player != null && !player.isCreative()) {
                 return stack.getItem() != ModItems.CREATIVE_STORAGE_UPGRADE.get() && stack.getItem() != ModItems.CREATIVE_VENDING_UPGRADE.get();
             }
         }
 
         return true;
-    }
-
-    public boolean canTakeStack () {
-        return mayPickup(null);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/EnumUpgradeCreative.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/EnumUpgradeCreative.java
@@ -1,6 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.item;
 
 import net.minecraft.util.StringRepresentable;
+import org.jetbrains.annotations.NotNull;
 
 public enum EnumUpgradeCreative implements StringRepresentable
 {
@@ -39,6 +40,7 @@ public enum EnumUpgradeCreative implements StringRepresentable
     }
 
     @Override
+    @NotNull
     public String getSerializedName () {
         return name;
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/EnumUpgradeRedstone.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/EnumUpgradeRedstone.java
@@ -1,6 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.item;
 
 import net.minecraft.util.StringRepresentable;
+import org.jetbrains.annotations.NotNull;
 
 public enum EnumUpgradeRedstone implements StringRepresentable
 {
@@ -40,6 +41,7 @@ public enum EnumUpgradeRedstone implements StringRepresentable
     }
 
     @Override
+    @NotNull
     public String getSerializedName () {
         return name;
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/EnumUpgradeStorage.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/EnumUpgradeStorage.java
@@ -1,6 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.item;
 
 import net.minecraft.util.StringRepresentable;
+import org.jetbrains.annotations.NotNull;
 
 public enum EnumUpgradeStorage implements StringRepresentable
 {
@@ -55,6 +56,7 @@ public enum EnumUpgradeStorage implements StringRepresentable
     }
 
     @Override
+    @NotNull
     public String getSerializedName () {
         return name;
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemCompDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemCompDrawers.java
@@ -25,7 +25,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemController.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemController.java
@@ -10,7 +10,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class ItemController extends ItemBlock

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemCustomDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemCustomDrawers.java
@@ -14,7 +14,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class ItemCustomDrawers extends ItemDrawers
 {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemDrawers.java
@@ -2,21 +2,22 @@ package com.jaquadro.minecraft.storagedrawers.item;
 
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 
 public class ItemDrawers extends BlockItem
@@ -27,7 +28,7 @@ public class ItemDrawers extends BlockItem
 
     @Override
     @OnlyIn(Dist.CLIENT)
-    public void appendHoverText (ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn) {
+    public void appendHoverText (@NotNull ItemStack stack, @Nullable Level worldIn, @NotNull List<Component> tooltip, @NotNull TooltipFlag flagIn) {
         super.appendHoverText(stack, worldIn, tooltip, flagIn);
 
         //if (stack.hasTag() && stack.getTag().contains("material")) {
@@ -38,7 +39,8 @@ public class ItemDrawers extends BlockItem
         Component textCapacity = new TranslatableComponent("tooltip.storagedrawers.drawers.capacity", getCapacityForBlock(stack));
         tooltip.add(new TextComponent("").append(textCapacity).withStyle(ChatFormatting.GRAY));
 
-        if (stack.hasTag() && stack.getTag().contains("tile")) {
+        CompoundTag tag = stack.getTagElement("tile");
+        if (tag != null) {
             Component textSealed = new TranslatableComponent("tooltip.storagedrawers.drawers.sealed");
             tooltip.add(new TextComponent("").append(textSealed).withStyle(ChatFormatting.YELLOW));
         }
@@ -47,15 +49,15 @@ public class ItemDrawers extends BlockItem
     }
 
     @OnlyIn(Dist.CLIENT)
+    @NotNull
     public Component getDescription() {
         return new TranslatableComponent(this.getDescriptionId() + ".desc");
     }
 
-    private int getCapacityForBlock (@Nonnull ItemStack itemStack) {
+    private int getCapacityForBlock (@NotNull ItemStack itemStack) {
         Block block = Block.byItem(itemStack.getItem());
-        if (block instanceof BlockDrawers) {
-            BlockDrawers drawers = (BlockDrawers)block;
-            return drawers.getStorageUnits() * CommonConfig.GENERAL.getBaseStackStorage();
+        if (block instanceof BlockDrawers blockDrawers) {
+            return blockDrawers.getStorageUnits() * CommonConfig.GENERAL.getBaseStackStorage();
         }
 
         return 0;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemKey.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemKey.java
@@ -5,31 +5,33 @@ import com.google.common.collect.Multimap;
 import com.jaquadro.minecraft.storagedrawers.api.storage.EmptyDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributesModifiable;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.item.TooltipFlag;
+import com.jaquadro.minecraft.storagedrawers.util.WorldUtils;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 public class ItemKey extends Item
@@ -47,18 +49,19 @@ public class ItemKey extends Item
     }
 
     @Override
-    public boolean canAttackBlock(BlockState state, Level worldIn, BlockPos pos, Player player) {
+    public boolean canAttackBlock(@NotNull BlockState state, @NotNull Level worldIn, @NotNull BlockPos pos, @NotNull Player player) {
         return !player.isCreative();
     }
 
     @Override
     @OnlyIn(Dist.CLIENT)
-    public void appendHoverText (ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn) {
+    public void appendHoverText (@NotNull ItemStack stack, @Nullable Level worldIn, @NotNull List<Component> tooltip, @NotNull TooltipFlag flagIn) {
         super.appendHoverText(stack, worldIn, tooltip, flagIn);
         tooltip.add(new TextComponent("").append(getDescription()).withStyle(ChatFormatting.GRAY));
     }
 
     @OnlyIn(Dist.CLIENT)
+    @NotNull
     public Component getDescription() {
         return new TranslatableComponent(this.getDescriptionId() + ".desc");
     }
@@ -69,12 +72,13 @@ public class ItemKey extends Item
     }
 
     @Override
+    @NotNull
     public InteractionResult useOn (UseOnContext context) {
-        BlockEntity tile = context.getLevel().getBlockEntity(context.getClickedPos());
-        if (tile == null)
+        BlockEntity blockEntity = WorldUtils.getBlockEntity(context.getLevel(), context.getClickedPos(), BlockEntity.class);
+        if (blockEntity == null)
             return InteractionResult.PASS;
 
-        IDrawerAttributes attrs = tile.getCapability(DRAWER_ATTRIBUTES_CAPABILITY, null).orElse(EmptyDrawerAttributes.EMPTY);
+        IDrawerAttributes attrs = blockEntity.getCapability(DRAWER_ATTRIBUTES_CAPABILITY, null).orElse(EmptyDrawerAttributes.EMPTY);
         if (!(attrs instanceof IDrawerAttributesModifiable))
             return InteractionResult.PASS;
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemPersonalKey.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemPersonalKey.java
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class ItemPersonalKey extends Item

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemUpgrade.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemUpgrade.java
@@ -1,18 +1,18 @@
 package com.jaquadro.minecraft.storagedrawers.item;
 
-import net.minecraft.world.item.TooltipFlag;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
-import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 
 public class ItemUpgrade extends Item
@@ -20,7 +20,7 @@ public class ItemUpgrade extends Item
     private static int nextGroupId = 0;
 
     private boolean allowMultiple;
-    private int groupId;
+    private final int groupId;
 
     public ItemUpgrade (Item.Properties properties) {
         this(properties, getNextGroupId());
@@ -43,11 +43,12 @@ public class ItemUpgrade extends Item
 
     @Override
     @OnlyIn(Dist.CLIENT)
-    public void appendHoverText (@Nonnull ItemStack itemStack, @Nullable Level world, List<Component> list, TooltipFlag advanced) {
+    public void appendHoverText (@NotNull ItemStack itemStack, @Nullable Level world, List<Component> list, TooltipFlag advanced) {
         list.add(new TextComponent("").append(getDescription()).withStyle(ChatFormatting.GRAY));
     }
 
     @OnlyIn(Dist.CLIENT)
+    @NotNull
     public Component getDescription() {
         return new TranslatableComponent(this.getDescriptionId() + ".desc");
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemUpgradeRedstone.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemUpgradeRedstone.java
@@ -4,7 +4,7 @@ import net.minecraft.world.item.Item;
 
 public class ItemUpgradeRedstone extends ItemUpgrade
 {
-    private static int redstoneGroupId;
+    private static final int redstoneGroupId;
     static {
         redstoneGroupId = ItemUpgrade.getNextGroupId();
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemUpgradeStorage.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemUpgradeStorage.java
@@ -1,15 +1,15 @@
 package com.jaquadro.minecraft.storagedrawers.item;
 
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
-import net.minecraft.world.item.Item;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.item.Item;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 public class ItemUpgradeStorage extends ItemUpgrade
 {
-    private static int storageGroupId;
+    private static final int storageGroupId;
     static {
         storageGroupId = ItemUpgrade.getNextGroupId();
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemUpgradeStorage.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemUpgradeStorage.java
@@ -6,6 +6,7 @@ import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import org.jetbrains.annotations.NotNull;
 
 public class ItemUpgradeStorage extends ItemUpgrade
 {
@@ -29,6 +30,7 @@ public class ItemUpgradeStorage extends ItemUpgrade
 
     @Override
     @OnlyIn(Dist.CLIENT)
+    @NotNull
     public Component getDescription() {
         int mult = CommonConfig.UPGRADES.getLevelMult(level.getLevel());
         return new TranslatableComponent("item.storagedrawers.storage_upgrade.desc", mult);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/pack/ItemDrawersPack.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/pack/ItemDrawersPack.java
@@ -6,7 +6,7 @@ import com.jaquadro.minecraft.storagedrawers.item.ItemBasicDrawers;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class ItemDrawersPack extends ItemBasicDrawers
 {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/pack/ItemTrimPack.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/pack/ItemTrimPack.java
@@ -6,7 +6,7 @@ import com.jaquadro.minecraft.storagedrawers.block.pack.BlockTrimPack;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class ItemTrimPack extends ItemTrim
 {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/network/CountUpdateMessage.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/network/CountUpdateMessage.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.network;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import net.minecraft.client.Minecraft;
@@ -73,8 +73,8 @@ public class CountUpdateMessage
             if (world != null) {
                 BlockPos pos = new BlockPos(msg.x, msg.y, msg.z);
                 BlockEntity blockEntity = world.getBlockEntity(pos);
-                if (blockEntity instanceof BlockEntityDrawers) {
-                    ((BlockEntityDrawers) blockEntity).clientUpdateCount(msg.slot, msg.count);
+                if (blockEntity instanceof TileEntityDrawers) {
+                    ((TileEntityDrawers) blockEntity).clientUpdateCount(msg.slot, msg.count);
                 }
             }
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/network/CountUpdateMessage.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/network/CountUpdateMessage.java
@@ -1,7 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.network;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import net.minecraft.client.Minecraft;
@@ -73,8 +73,8 @@ public class CountUpdateMessage
             if (world != null) {
                 BlockPos pos = new BlockPos(msg.x, msg.y, msg.z);
                 BlockEntity blockEntity = world.getBlockEntity(pos);
-                if (blockEntity instanceof TileEntityDrawers) {
-                    ((TileEntityDrawers) blockEntity).clientUpdateCount(msg.slot, msg.count);
+                if (blockEntity instanceof BlockEntityDrawers) {
+                    ((BlockEntityDrawers) blockEntity).clientUpdateCount(msg.slot, msg.count);
                 }
             }
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/network/CountUpdateMessage.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/network/CountUpdateMessage.java
@@ -1,14 +1,14 @@
 package com.jaquadro.minecraft.storagedrawers.network;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import net.minecraft.client.Minecraft;
-import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fml.DistExecutor;
@@ -24,7 +24,7 @@ public class CountUpdateMessage
     private int slot;
     private int count;
 
-    private boolean failed;
+    private final boolean failed;
 
     public CountUpdateMessage (BlockPos pos, int slot, int count) {
         this.x = pos.getX();
@@ -72,9 +72,9 @@ public class CountUpdateMessage
             Level world = Minecraft.getInstance().level;
             if (world != null) {
                 BlockPos pos = new BlockPos(msg.x, msg.y, msg.z);
-                BlockEntity tileEntity = world.getBlockEntity(pos);
-                if (tileEntity instanceof TileEntityDrawers) {
-                    ((TileEntityDrawers) tileEntity).clientUpdateCount(msg.slot, msg.count);
+                BlockEntity blockEntity = world.getBlockEntity(pos);
+                if (blockEntity instanceof BlockEntityDrawers) {
+                    ((BlockEntityDrawers) blockEntity).clientUpdateCount(msg.slot, msg.count);
                 }
             }
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/security/SecurityManager.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/security/SecurityManager.java
@@ -6,7 +6,7 @@ import com.mojang.authlib.GameProfile;
 
 public class SecurityManager
 {
-    private static ISecurityProvider defaultProvider = new DefaultSecurityProvider();
+    private static final ISecurityProvider defaultProvider = new DefaultSecurityProvider();
 
     public static boolean hasOwnership (GameProfile profile, IProtectable target) {
         if (target == null || profile == null)

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/security/SecurityRegistry.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/security/SecurityRegistry.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class SecurityRegistry
 {
-    private Map<String, ISecurityProvider> registry = new HashMap<String, ISecurityProvider>();
+    private final Map<String, ISecurityProvider> registry = new HashMap<>();
 
     public void registerProvider (ISecurityProvider provider) {
         registry.put(provider.getProviderID(), provider);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/util/CompactingHelper.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/util/CompactingHelper.java
@@ -3,39 +3,39 @@ package com.jaquadro.minecraft.storagedrawers.util;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.config.CommonConfig;
 import com.jaquadro.minecraft.storagedrawers.config.CompTierRegistry;
+import net.minecraft.core.NonNullList;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeType;
-import net.minecraft.world.item.crafting.Ingredient;
-import net.minecraft.core.NonNullList;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.*;
 
 public class CompactingHelper
 {
-    private static InventoryLookup lookup1 = new InventoryLookup(1, 1);
-    private static InventoryLookup lookup2 = new InventoryLookup(2, 2);
-    private static InventoryLookup lookup3 = new InventoryLookup(3, 3);
+    private static final InventoryLookup lookup1 = new InventoryLookup(1, 1);
+    private static final InventoryLookup lookup2 = new InventoryLookup(2, 2);
+    private static final InventoryLookup lookup3 = new InventoryLookup(3, 3);
 
-    private Level world;
+    private final Level world;
 
-    public class Result
+    public static class Result
     {
-        @Nonnull
-        private ItemStack stack;
-        private int size;
+        @NotNull
+        private final ItemStack stack;
+        private final int size;
 
-        public Result (ItemStack stack, int size) {
+        public Result (@NotNull ItemStack stack, int size) {
             this.stack = stack;
             this.size = size;
         }
 
-        @Nonnull
+        @NotNull
         public ItemStack getStack () {
             return stack;
         }
@@ -49,8 +49,8 @@ public class CompactingHelper
         this.world = world;
     }
 
-    @Nonnull
-    public Result findHigherTier (@Nonnull ItemStack stack) {
+    @NotNull
+    public Result findHigherTier (@NotNull ItemStack stack) {
         boolean debugTrace = CommonConfig.GENERAL.debugTrace.get();
         if (!world.isClientSide && debugTrace)
             StorageDrawers.log.info("Finding ascending candidates for " + stack.toString());
@@ -108,8 +108,8 @@ public class CompactingHelper
         return new Result(ItemStack.EMPTY, 0);
     }
 
-    @Nonnull
-    public Result findLowerTier (@Nonnull ItemStack stack) {
+    @NotNull
+    public Result findLowerTier (@NotNull ItemStack stack) {
         boolean debugTrace = CommonConfig.GENERAL.debugTrace.get();
         if (!world.isClientSide && debugTrace)
             StorageDrawers.log.info("Finding descending candidates for " + stack.toString());
@@ -131,7 +131,7 @@ public class CompactingHelper
             if (!ItemStackMatcher.areItemsEqual(stack, output))
                 continue;
 
-            @Nonnull ItemStack match = tryMatch(stack, recipe.getIngredients());
+            @NotNull ItemStack match = tryMatch(stack, recipe.getIngredients());
             if (!match.isEmpty()) {
                 int lookupSize = setupLookup(lookup1, output);
                 List<ItemStack> compMatches = findAllMatchingRecipes(lookup1);
@@ -179,8 +179,8 @@ public class CompactingHelper
         return candidates;
     }
 
-    @Nonnull
-    private ItemStack findMatchingModCandidate (@Nonnull ItemStack reference, List<ItemStack> candidates) {
+    @NotNull
+    private ItemStack findMatchingModCandidate (@NotNull ItemStack reference, List<ItemStack> candidates) {
         ResourceLocation referenceName = reference.getItem().getRegistryName();
         if (referenceName != null) {
             for (ItemStack candidate : candidates) {
@@ -195,8 +195,8 @@ public class CompactingHelper
         return ItemStack.EMPTY;
     }
 
-    @Nonnull
-    private ItemStack tryMatch (@Nonnull ItemStack stack, NonNullList<Ingredient> ingredients) {
+    @NotNull
+    private ItemStack tryMatch (@NotNull ItemStack stack, NonNullList<Ingredient> ingredients) {
         if (ingredients.size() != 9 && ingredients.size() != 4)
             return ItemStack.EMPTY;
 
@@ -207,7 +207,7 @@ public class CompactingHelper
 
         for (int i = 1, n = ingredients.size(); i < n; i++) {
             Ingredient ingredient = ingredients.get(i);
-            @Nonnull ItemStack match = ItemStack.EMPTY;
+            @NotNull ItemStack match = ItemStack.EMPTY;
 
             for (ItemStack ingItemMatch : refMatchingStacks) {
                 if (ingredient.test(ingItemMatch)) {
@@ -227,7 +227,7 @@ public class CompactingHelper
         return match;
     }
 
-    private int setupLookup (InventoryLookup inv, @Nonnull ItemStack stack) {
+    private int setupLookup (InventoryLookup inv, @NotNull ItemStack stack) {
         for (int i = 0, n = inv.getContainerSize(); i < n; i++)
             inv.setItem(i, stack);
 
@@ -236,14 +236,13 @@ public class CompactingHelper
 
     private static class InventoryLookup extends CraftingContainer
     {
-        private ItemStack[] stackList;
+        private final ItemStack[] stackList;
 
         public InventoryLookup (int width, int height) {
             super(null, width, height);
 
             stackList = new ItemStack[width * height];
-            for (int i = 0; i < stackList.length; i++)
-                stackList[i] = ItemStack.EMPTY;
+            Arrays.fill(stackList, ItemStack.EMPTY);
         }
 
         @Override
@@ -253,26 +252,26 @@ public class CompactingHelper
         }
 
         @Override
-        @Nonnull
+        @NotNull
         public ItemStack getItem (int slot)
         {
             return slot >= this.getContainerSize() ? ItemStack.EMPTY : this.stackList[slot];
         }
 
         @Override
-        @Nonnull
+        @NotNull
         public ItemStack removeItemNoUpdate (int slot) {
             return ItemStack.EMPTY;
         }
 
         @Override
-        @Nonnull
+        @NotNull
         public ItemStack removeItem (int slot, int count) {
             return ItemStack.EMPTY;
         }
 
         @Override
-        public void setItem (int slot, @Nonnull ItemStack stack) {
+        public void setItem (int slot, @NotNull ItemStack stack) {
             stackList[slot] = stack;
         }
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/util/ItemCollectionRegistry.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/util/ItemCollectionRegistry.java
@@ -6,7 +6,7 @@ import java.util.*;
 
 public class ItemCollectionRegistry<E>
 {
-    private Map<Item, Collection<E>> registry;
+    private final Map<Item, Collection<E>> registry;
 
     public ItemCollectionRegistry () {
         this.registry = new HashMap<>();

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/util/ItemStackMatcher.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/util/ItemStackMatcher.java
@@ -1,25 +1,24 @@
 package com.jaquadro.minecraft.storagedrawers.util;
 
 import net.minecraft.world.item.ItemStack;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ItemStackMatcher
 {
     public static ItemStackMatcher EMPTY = new ItemStackMatcher(ItemStack.EMPTY);
 
-    @Nonnull
+    @NotNull
     protected ItemStack stack;
 
-    public ItemStackMatcher (@Nonnull ItemStack stack) {
+    public ItemStackMatcher (@NotNull ItemStack stack) {
         this.stack = stack;
     }
 
-    public boolean matches (@Nonnull ItemStack stack) {
+    public boolean matches (@NotNull ItemStack stack) {
         return areItemsEqual(this.stack, stack);
     }
 
-    public static boolean areItemsEqual (@Nonnull ItemStack stack1, @Nonnull ItemStack stack2) {
+    public static boolean areItemsEqual (@NotNull ItemStack stack1, @NotNull ItemStack stack2) {
         if (!stack1.sameItem(stack2))
             return false;
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/util/WorldUtils.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/util/WorldUtils.java
@@ -1,0 +1,32 @@
+package com.jaquadro.minecraft.storagedrawers.util;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
+
+public final class WorldUtils {
+    private WorldUtils() {}
+
+    public static BlockHitResult rayTraceEyes(Level level, Player player, BlockPos blockPos) {
+        Vec3 eyePos = player.getEyePosition(1);
+        Vec3 lookVector = player.getViewVector(1);
+        Vec3 endPos = eyePos.add(lookVector.scale(eyePos.distanceTo(Vec3.atCenterOf(blockPos)) + 1));
+        ClipContext context = new ClipContext(eyePos, endPos, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, player);
+        return level.clip(context);
+    }
+
+    @Nullable
+    public static <BE extends BlockEntity> BE getBlockEntity(BlockGetter level, BlockPos blockPos, Class<BE> blockEntityClass) {
+        if (level instanceof Level && !((Level) level).isLoaded(blockPos))
+            return null;
+
+        BlockEntity blockEntity = level.getBlockEntity(blockPos);
+        return blockEntityClass.isInstance(blockEntity) ? blockEntityClass.cast(blockEntity) : null;
+    }
+}

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/util/WorldUtils.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/util/WorldUtils.java
@@ -8,12 +8,14 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class WorldUtils {
     private WorldUtils() {}
 
-    public static BlockHitResult rayTraceEyes(Level level, Player player, BlockPos blockPos) {
+    @NotNull
+    public static BlockHitResult rayTraceEyes(@NotNull Level level, @NotNull Player player, @NotNull BlockPos blockPos) {
         Vec3 eyePos = player.getEyePosition(1);
         Vec3 lookVector = player.getViewVector(1);
         Vec3 endPos = eyePos.add(lookVector.scale(eyePos.distanceTo(Vec3.atCenterOf(blockPos)) + 1));
@@ -22,7 +24,7 @@ public final class WorldUtils {
     }
 
     @Nullable
-    public static <BE extends BlockEntity> BE getBlockEntity(BlockGetter level, BlockPos blockPos, Class<BE> blockEntityClass) {
+    public static <BE extends BlockEntity> BE getBlockEntity(@NotNull BlockGetter level, @NotNull BlockPos blockPos, @NotNull Class<BE> blockEntityClass) {
         if (level instanceof Level && !((Level) level).isLoaded(blockPos))
             return null;
 

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -42,6 +42,20 @@
         "storagedrawers:dark_oak_half_drawers_1",
         "storagedrawers:dark_oak_half_drawers_2",
         "storagedrawers:dark_oak_half_drawers_4",
-        "storagedrawers:dark_oak_trim"
+        "storagedrawers:dark_oak_trim",
+        "storagedrawers:crimson_full_drawers_1",
+        "storagedrawers:crimson_full_drawers_2",
+        "storagedrawers:crimson_full_drawers_4",
+        "storagedrawers:crimson_half_drawers_1",
+        "storagedrawers:crimson_half_drawers_2",
+        "storagedrawers:crimson_half_drawers_4",
+        "storagedrawers:crimson_trim",
+        "storagedrawers:warped_full_drawers_1",
+        "storagedrawers:warped_full_drawers_2",
+        "storagedrawers:warped_full_drawers_4",
+        "storagedrawers:warped_half_drawers_1",
+        "storagedrawers:warped_half_drawers_2",
+        "storagedrawers:warped_half_drawers_4",
+        "storagedrawers:warped_trim"
     ]
 }


### PR DESCRIPTION
The primary goal of this PR is to improve rightclicking and leftclicking behavior; most of these changes can be found in `BlockDrawers`.

- Leftclick now only happens when you actually leftclick the block, removed other hooks that invoked it in unexpected places.
- Removed CommonProxy and ClientProxy, added a simple bus subscriber that handles leftclicks in creative mode.
- Destroying drawers in creative mode now creates proper sound and particles, instead of just deleting it from existence.
- It is now possible to click drawers from the front without interacting by aiming at the 1-pixel rim around them (includes half-drawers).

Additional changes:

- ~~Renamed TileEntities to BlockEntities almost everywhere except package names and NBT tags.~~ ~~This change was reverted.~~ This change was un-reverted since there are some breaking changes for addon makers anyway.
- BlockEntities now invalidate their capability holders when removed. To facilitate this, a new method was added to ~~`BlockEntityDataShim`~~ ~~`TileEntityDataShim`~~ `BlockEntityDataShim`.

While doing this I got sidetracked and did a bunch of refactoring that probably wouldn't fit into a separate PR.

- Sprinkled nullability annotations where they were suggested and made sure they come from Jetbrains instead of jsr305.
- Did a bunch of IDEA-suggested refactoring, usually simple null checks.