### PR TITLE
Compacting drawer item duplication fix for 1.16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,23 +92,32 @@ repositories {
     maven {
         name = "JEI"
         url "https://dvs1.progwml6.com/files/maven"
+        content {
+            includeGroup 'mezz.jei'
+        }
     }
-    maven {
-        name = "CraftTweaker"
-        url "https://maven.blamejared.com/"
-    }
+//    maven {
+//        name = "CraftTweaker"
+//        url "https://maven.blamejared.com/"
+//    }
     maven {
         name 'TOP'
         url "https://maven.tterrag.com/"
+        content {
+            includeGroup 'mcjty.theoneprobe'
+        }
     }
     maven {
         name = "HWYLA"
         url "https://maven.tehnut.info"
+        content {
+            includeGroup 'mcp.mobius.waila'
+        }
     }
-    maven {
-        name = "CurseForge"
-        url = "https://minecraft.curseforge.com/api/maven"
-    }
+//    maven {
+//        name = "CurseForge"
+//        url = "https://minecraft.curseforge.com/api/maven"
+//    }
 }
 
 dependencies {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/FractionalDrawerGroup.java
@@ -488,18 +488,19 @@ public class FractionalDrawerGroup extends TileDataShim implements IDrawerGroup
             lookupTarget = itemPrototype;
             for (; index < slotCount; index++) {
                 CompactingHelper.Result lookup = compacting.findLowerTier(lookupTarget);
-                if (lookup.getStack().isEmpty())
-                    break;
+                ItemStack itemStack = lookup.getStack();
+                if (!itemStack.isEmpty()) {
+                    populateRawSlot(index, itemStack, 1);
+                    group.log("Picked candidate " + itemStack + " with conv=" + lookup.getSize());
 
-                populateRawSlot(index, lookup.getStack(), 1);
-                group.log("Picked candidate " + lookup.getStack().toString() + " with conv=" + lookup.getSize());
-
-                for (int i = 0; i < index; i++) {
-                    convRate[i] *= lookup.getSize();
-                    cachedConvRate[i] = convRate[i];
+                    for (int i = 0; i < index; i++) {
+                        convRate[i] *= lookup.getSize();
+                        cachedConvRate[i] = convRate[i];
+                    }
+                } else {
+                    populateRawSlot(index, ItemStack.EMPTY, 0);
                 }
-
-                lookupTarget = lookup.getStack();
+                lookupTarget = itemStack;
             }
         }
 


### PR DESCRIPTION
This PR is a 1.16 backport fix for the item duplication bug outlined in issue https://github.com/jaquadro/StorageDrawers/issues/1009. The 1.18 version of the fix will be located in this PR: https://github.com/jaquadro/StorageDrawers/pull/1016 (though the actual code chages are the same).

The bug happens after fully taking out items from a compacting drawer and then putting in a different item, which takes up less slots in the drawer (has less compacting variants).

For example, a drawer stored iron blocks, ingots and nuggets. Player takes out all of them (the drawer becomes empty) and puts in clay. Clay has only 2 compacting variants as opposed to iron's 3 - clay blocks and clay balls. This is when the error happens - the cached value for the 3rd drawer doesn't get reset and still holds iron nuggets. However, the bug isn't noticeable yet, as all the slots are currently being built from scratch and the cache is untouched.
Problems start when you fully take out clay and put it in again. This time, the input item matches the cached value, so slots get loaded from the cache in their entirety, resulting in a drawer with clay blocks, clay balls and iron ingots.

The fix makes sure that all remaining slots get reset instead of ending the loop early.
Additionaly, some minor changes were made to build.gradle to make sure that the project loads properly.