### PR TITLE
Fix Waila Integration, Add TOP Integration, Fix Pick Block

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ baubles_file_id = 2518667
 # Buildscript Dep Runtime Settings (If these mods should be included when you run the mod in a dev environment)
 # Mainly used to see if mod integration works.
 # TOP is actually not incompatable with WAILA. You can enable both for testing if you want.
-debug_jei = false
-debug_thaumcraft = false
-debug_waila = false
-debug_top = false
+debug_jei = true
+debug_thaumcraft = true
+debug_waila = true
+debug_top = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ baubles_file_id = 2518667
 # Buildscript Dep Runtime Settings (If these mods should be included when you run the mod in a dev environment)
 # Mainly used to see if mod integration works.
 # TOP is actually not incompatable with WAILA. You can enable both for testing if you want.
-debug_jei = true
-debug_thaumcraft = true
-debug_waila = true
-debug_top = true
+debug_jei = false
+debug_thaumcraft = false
+debug_waila = false
+debug_top = false

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -55,6 +55,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public abstract class BlockDrawers extends BlockContainer implements INetworked
 {
@@ -581,7 +582,39 @@ public abstract class BlockDrawers extends BlockContainer implements INetworked
 
     @Override
     public ItemStack getPickBlock (IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player) {
-        return getMainDrop(world, pos, state);
+        ItemStack drop = getMainDrop(world, pos, state);
+
+        // If no tile data was written. Note that hasTagCompound returns false if the tag compound is null.
+        if (!drop.hasTagCompound() || !Objects.requireNonNull(drop.getTagCompound()).hasKey("tile"))
+            return drop;
+
+        // Remove tile data
+        NBTTagCompound compound = drop.getTagCompound();
+        compound.removeTag("tile");
+        drop.setTagCompound(compound);
+
+        return drop;
+    }
+
+    public ItemStack getWailaTOPBlock(World world, BlockPos pos, IBlockState state) {
+        ItemStack drop = getMainDrop(world, pos, state);
+
+        // If no tile data was written. Note that hasTagCompound returns false if the tag compound is null.
+        if (!drop.hasTagCompound() || !Objects.requireNonNull(drop.getTagCompound()).hasKey("tile"))
+            return drop;
+
+        TileEntityDrawers tile = (TileEntityDrawers) world.getTileEntity(pos);
+
+        // If we don't need to remove tile data
+        if (tile != null && tile.isSealed())
+            return drop;
+
+        // Remove tile data
+        NBTTagCompound compound = drop.getTagCompound();
+        compound.removeTag("tile");
+        drop.setTagCompound(compound);
+
+        return drop;
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockTrim.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockTrim.java
@@ -16,6 +16,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
@@ -79,6 +80,11 @@ public class BlockTrim extends Block implements INetworked
         drops.add(dropStack);
 
         return drops;
+    }
+
+    @Override
+    public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player) {
+        return getMainDrop(world, pos, state);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockTrimCustom.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockTrimCustom.java
@@ -9,11 +9,13 @@ import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.property.ExtendedBlockState;
@@ -58,6 +60,11 @@ public class BlockTrimCustom extends BlockTrim implements ITileEntityProvider
             return ItemCustomTrim.makeItemStack(this, 1, ItemStack.EMPTY, ItemStack.EMPTY);
 
         return ItemCustomTrim.makeItemStack(this, 1, tile.material().getSide(), tile.material().getTrim());
+    }
+
+    @Override
+    public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player) {
+        return getMainDrop(world, pos, state);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/config/ConfigManager.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/config/ConfigManager.java
@@ -70,6 +70,7 @@ public class ConfigManager
         public boolean enableSidedOutput;
         public boolean enableItemConversion;
         public boolean enableWailaIntegration;
+        public boolean enableTOPIntegration;
         public boolean enableThaumcraftIntegration;
         public boolean enableMineTweakerIntegration;
         public boolean enableTape;
@@ -165,8 +166,15 @@ public class ConfigManager
         cache.keepContentsOnBreak = config.get(Configuration.CATEGORY_GENERAL, "keepContentsOnBreak", true).setLanguageKey(LANG_PREFIX + "prop.keepContentsOnBreak").getBoolean();
 
         //cache.enableAE2Integration = config.get(sectionIntegration.getQualifiedName(), "enableAE2", true).setLanguageKey(LANG_PREFIX + "integration.enableAE2").setRequiresMcRestart(true).getBoolean();
-        cache.enableWailaIntegration = config.get(sectionIntegration.getQualifiedName(), "enableWaila", true).setLanguageKey(LANG_PREFIX + "integration.enableWaila").setRequiresMcRestart(true).getBoolean();
-        cache.enableThaumcraftIntegration = config.get(sectionIntegration.getQualifiedName(), "enableThaumcraft", true).setLanguageKey(LANG_PREFIX + "integration.enableThaumcraft").setRequiresMcRestart(true).getBoolean();
+        cache.enableWailaIntegration = config.get(sectionIntegration.getQualifiedName(), "enableWaila", true,
+                "Whether to enable What Am I Looking At integration, overriding default displayed blocks, and adding several Storage Drawers related options to the config. Warning: Turning this off will make Waila display some Storage Drawers blocks incorrectly.")
+                .setLanguageKey(LANG_PREFIX + "integration.enableWaila").setRequiresMcRestart(true).getBoolean();
+        cache.enableTOPIntegration = config.get(sectionIntegration.getQualifiedName(), "enableTOP", true,
+                "Whether to enable The One Probe integration, overriding default displayed blocks. Warning: Turning this off will make TOP display some Storage Drawers blocks incorrectly.")
+                .setLanguageKey(LANG_PREFIX + "integration.enableTOP").setRequiresMcRestart(true).getBoolean();
+        cache.enableThaumcraftIntegration = config.get(sectionIntegration.getQualifiedName(), "enableThaumcraft", true,
+                "Whether to enable Thaumcraft integration, adding icons on drawers if the item stored has an Aspect.")
+                .setLanguageKey(LANG_PREFIX + "integration.enableThaumcraft").setRequiresMcRestart(true).getBoolean();
         cache.enableMineTweakerIntegration = config.get(sectionIntegration.getQualifiedName(), "enableMineTweaker", true).setLanguageKey(LANG_PREFIX + "integration.enableMineTweaker").setRequiresMcRestart(true).getBoolean();
 
         cache.compRules = config.getStringList("compactingRules", sectionRegistries.getQualifiedName(), new String[] { "minecraft:clay, minecraft:clay_ball, 4" }, "Items should be in form domain:item or domain:item:meta.", null, LANG_PREFIX + "registries.compRules");

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/config/ConfigManager.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/config/ConfigManager.java
@@ -167,13 +167,13 @@ public class ConfigManager
 
         //cache.enableAE2Integration = config.get(sectionIntegration.getQualifiedName(), "enableAE2", true).setLanguageKey(LANG_PREFIX + "integration.enableAE2").setRequiresMcRestart(true).getBoolean();
         cache.enableWailaIntegration = config.get(sectionIntegration.getQualifiedName(), "enableWaila", true,
-                "Whether to enable What Am I Looking At integration, overriding default displayed blocks, and adding several Storage Drawers related options to the config. Warning: Turning this off will make Waila display some Storage Drawers blocks incorrectly.")
+                "Whether to enable What Am I Looking At integration, which overrides the displayed block for Storage Drawers related blocks, and adds several Storage Drawers related options to the config. Warning: Turning this off will make Waila display some Storage Drawers blocks incorrectly.")
                 .setLanguageKey(LANG_PREFIX + "integration.enableWaila").setRequiresMcRestart(true).getBoolean();
         cache.enableTOPIntegration = config.get(sectionIntegration.getQualifiedName(), "enableTOP", true,
-                "Whether to enable The One Probe integration, overriding default displayed blocks. Warning: Turning this off will make TOP display some Storage Drawers blocks incorrectly.")
+                "Whether to enable The One Probe integration, which overrides the displayed block for Storage Drawers related blocks. Warning: Turning this off will make TOP display some Storage Drawers blocks incorrectly.")
                 .setLanguageKey(LANG_PREFIX + "integration.enableTOP").setRequiresMcRestart(true).getBoolean();
         cache.enableThaumcraftIntegration = config.get(sectionIntegration.getQualifiedName(), "enableThaumcraft", true,
-                "Whether to enable Thaumcraft integration, adding icons on drawers if the item stored has an Aspect.")
+                "Whether to enable Thaumcraft integration, which adding icons on drawers if the item stored has an Aspect.")
                 .setLanguageKey(LANG_PREFIX + "integration.enableThaumcraft").setRequiresMcRestart(true).getBoolean();
         cache.enableMineTweakerIntegration = config.get(sectionIntegration.getQualifiedName(), "enableMineTweaker", true).setLanguageKey(LANG_PREFIX + "integration.enableMineTweaker").setRequiresMcRestart(true).getBoolean();
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/TOP.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/TOP.java
@@ -18,7 +18,7 @@ public class TOP {
         ITheOneProbe TOP = TheOneProbe.theOneProbeImp;
         TOP.registerBlockDisplayOverride(new DrawerLogoProvider());
     }
-    public static class DrawerLogoProvider implements IBlockDisplayOverride {
+    private static class DrawerLogoProvider implements IBlockDisplayOverride {
         @Override
         public boolean overrideStandardInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer entityPlayer, World world, IBlockState blockState, IProbeHitData probeHitData) {
             // Returns false if no override is needed

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/TOP.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/TOP.java
@@ -1,0 +1,45 @@
+package com.jaquadro.minecraft.storagedrawers.core;
+
+import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
+import mcjty.theoneprobe.TheOneProbe;
+import mcjty.theoneprobe.Tools;
+import mcjty.theoneprobe.api.*;
+import mcjty.theoneprobe.config.Config;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+import static mcjty.theoneprobe.api.TextStyleClass.MODNAME;
+
+public class TOP {
+    public static void registerProviders() {
+        ITheOneProbe TOP = TheOneProbe.theOneProbeImp;
+        TOP.registerBlockDisplayOverride(new DrawerLogoProvider());
+    }
+    public static class DrawerLogoProvider implements IBlockDisplayOverride {
+        @Override
+        public boolean overrideStandardInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer entityPlayer, World world, IBlockState blockState, IProbeHitData probeHitData) {
+            // Returns false if no override is needed
+            Block block = blockState.getBlock();
+            if (!(block instanceof BlockDrawers))
+                return false;
+
+            ItemStack pickBlock = ((BlockDrawers) block).getWailaTOPBlock(world, probeHitData.getPos(), blockState);
+
+            if (Tools.show(mode, Config.getRealConfig().getShowModName()))
+                probeInfo.horizontal()
+                        .item(pickBlock)
+                        .vertical()
+                        .itemLabel(pickBlock)
+                        .text(MODNAME + Tools.getModName(block));
+            else
+                probeInfo.horizontal(probeInfo.defaultLayoutStyle()
+                                .alignment(ElementAlignment.ALIGN_CENTER))
+                        .item(pickBlock);
+
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/LocalIntegrationRegistry.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/LocalIntegrationRegistry.java
@@ -2,6 +2,7 @@ package com.jaquadro.minecraft.storagedrawers.integration;
 
 import com.jaquadro.minecraft.chameleon.integration.IntegrationRegistry;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
+import com.jaquadro.minecraft.storagedrawers.core.TOP;
 import net.minecraftforge.fml.common.Loader;
 
 public class LocalIntegrationRegistry
@@ -14,6 +15,8 @@ public class LocalIntegrationRegistry
             reg.add(new Waila());
         if (Loader.isModLoaded("thaumcraft") && StorageDrawers.config.cache.enableThaumcraftIntegration)
             reg.add(new Thaumcraft());
+        if (Loader.isModLoaded("theoneprobe") && StorageDrawers.config.cache.enableTOPIntegration)
+            TOP.registerProviders();
         //if (Loader.isModLoaded("appliedenergistics2") && StorageDrawers.config.cache.enableAE2Integration)
         //    reg.add(new AppliedEnergistics());
         //if (Loader.isModLoaded("crafttweaker") && StorageDrawers.config.cache.enableMineTweakerIntegration)

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
@@ -84,20 +84,23 @@ public class Waila extends IntegrationModule
         @Override
         @Nonnull
         public ItemStack getWailaStack (IWailaDataAccessor accessor, IWailaConfigHandler config) {
-            Block block = accessor.getBlock();
             // Only replace info if it needs to (trim or drawers). Else, leave it, some other mod might change it.
-            if (!(block instanceof BlockDrawers)){
-                if (block instanceof BlockTrim){
-                    NonNullList<ItemStack> drops = NonNullList.create();
-                    accessor.getBlock().getDrops(drops, accessor.getWorld(), accessor.getPosition(), accessor.getBlockState(), 0);
-                    if (drops.size() == 0)
-                        return ItemStack.EMPTY;
+            // Returning ItemStack.EMPTY tells Hwyla that an override is not required.
 
-                    return drops.get(0);
-                }
-                return ItemStack.EMPTY;
+            Block block = accessor.getBlock();
+
+            if ((block instanceof BlockDrawers))
+                return ((BlockDrawers) accessor.getBlock()).getWailaTOPBlock(accessor.getWorld(), accessor.getPosition(), accessor.getBlockState());
+
+            if (block instanceof BlockTrim){
+                List<ItemStack> drops = ((BlockTrim) block).getDrops(accessor.getWorld(), accessor.getPosition(), accessor.getBlockState(), 0);
+                if (drops == null || drops.isEmpty())
+                    return ItemStack.EMPTY;
+
+                return drops.get(0);
             }
-            return ((BlockDrawers) accessor.getBlock()).getWailaTOPBlock(accessor.getWorld(), accessor.getPosition(), accessor.getBlockState());
+
+            return ItemStack.EMPTY;
         }
 
         @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
@@ -9,6 +9,7 @@ import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IFractionalDrawer;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.BlockTrim;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.capabilities.CapabilityDrawerAttributes;
 import com.jaquadro.minecraft.storagedrawers.security.SecurityManager;
@@ -16,6 +17,7 @@ import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaDataProvider;
 import mcp.mobius.waila.api.IWailaRegistrar;
+import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -73,6 +75,7 @@ public class Waila extends IntegrationModule
         }
         catch (Exception e) {
             // Oh well, we couldn't hook the waila config
+            StorageDrawers.log.error("Failed to hook the Waila Config. Could not add in custom Storage Drawers related configs.");
         }
     }
 
@@ -81,12 +84,20 @@ public class Waila extends IntegrationModule
         @Override
         @Nonnull
         public ItemStack getWailaStack (IWailaDataAccessor accessor, IWailaConfigHandler config) {
-            NonNullList<ItemStack> drops = NonNullList.create();
-            accessor.getBlock().getDrops(drops, accessor.getWorld(), accessor.getPosition(), accessor.getBlockState(), 0);
-            if (drops.size() == 0)
-                return ItemStack.EMPTY;
+            Block block = accessor.getBlock();
+            // Only replace info if it needs to (trim or drawers). Else, leave it, some other mod might change it.
+            if (!(block instanceof BlockDrawers)){
+                if (block instanceof BlockTrim){
+                    NonNullList<ItemStack> drops = NonNullList.create();
+                    accessor.getBlock().getDrops(drops, accessor.getWorld(), accessor.getPosition(), accessor.getBlockState(), 0);
+                    if (drops.size() == 0)
+                        return ItemStack.EMPTY;
 
-            return drops.get(0);
+                    return drops.get(0);
+                }
+                return ItemStack.EMPTY;
+            }
+            return ((BlockDrawers) accessor.getBlock()).getWailaTOPBlock(accessor.getWorld(), accessor.getPosition(), accessor.getBlockState());
         }
 
         @Override

--- a/src/main/resources/assets/storagedrawers/lang/de_de.lang
+++ b/src/main/resources/assets/storagedrawers/lang/de_de.lang
@@ -197,6 +197,7 @@ storagedrawers.config.integration.tooltip=Konfiguriere Integration mit anderen M
 
 storagedrawers.config.integration.enableAE2=Erlaube Applied Energistics 2 Integration
 storagedrawers.config.integration.enableWaila=Erlaube WAILA Integration
+storagedrawers.config.integration.enableWaila=Erlaube TOP Integration
 storagedrawers.config.integration.enableThaumcraft=Erlaube Thaumcraft Integration
 storagedrawers.config.integration.enableMineTweaker=Erlaube MineTweaker Integration
 

--- a/src/main/resources/assets/storagedrawers/lang/en_us.lang
+++ b/src/main/resources/assets/storagedrawers/lang/en_us.lang
@@ -207,6 +207,7 @@ storagedrawers.config.integration.tooltip=Configure integration with other mods.
 
 storagedrawers.config.integration.enableAE2=Enable Applied Energistics 2 Integration
 storagedrawers.config.integration.enableWaila=Enable WAILA Integration
+storagedrawers.config.integration.enableTOP=Enable TOP Integration
 storagedrawers.config.integration.enableThaumcraft=Enable Thaumcraft Integration
 storagedrawers.config.integration.enableMineTweaker=Enable MineTweaker Integration
 

--- a/src/main/resources/assets/storagedrawers/lang/es_ar.lang
+++ b/src/main/resources/assets/storagedrawers/lang/es_ar.lang
@@ -104,3 +104,6 @@ storagedrawers.config.integration.tooltip=Configure integration with other mods.
 
 storagedrawers.config.integration.enableAE2=Enable Applied Energistics 2 Integration
 storagedrawers.config.integration.enableWaila=Enable WAILA Integration
+storagedrawers.config.integration.enableTOP=Enable TOP Integration
+storagedrawers.config.integration.enableThaumcraft=Enable Thaumcraft Integration
+storagedrawers.config.integration.enableMineTweaker=Enable MineTweaker Integration

--- a/src/main/resources/assets/storagedrawers/lang/fr_fr.lang
+++ b/src/main/resources/assets/storagedrawers/lang/fr_fr.lang
@@ -197,6 +197,7 @@ storagedrawers.config.integration.tooltip=Configure l'intégration avec d'autres
 
 storagedrawers.config.integration.enableAE2=Active l'intégration de Applied Energistics 2
 storagedrawers.config.integration.enableWaila=Active l'intégration de WAILA
+storagedrawers.config.integration.enableTOP=Active l'intégration de TOP
 storagedrawers.config.integration.enableThaumcraft=Active l'intégration de Thaumcraft
 storagedrawers.config.integration.enableMineTweaker=Active l'intégration de MineTweaker
 

--- a/src/main/resources/assets/storagedrawers/lang/he_il.lang
+++ b/src/main/resources/assets/storagedrawers/lang/he_il.lang
@@ -104,3 +104,6 @@ storagedrawers.config.integration.tooltip=Configure integration with other mods.
 
 storagedrawers.config.integration.enableAE2=Enable Applied Energistics 2 Integration
 storagedrawers.config.integration.enableWaila=Enable WAILA Integration
+storagedrawers.config.integration.enableTOP=Enable TOP Integration
+storagedrawers.config.integration.enableThaumcraft=Enable Thaumcraft Integration
+storagedrawers.config.integration.enableMineTweaker=Enable MineTweaker Integration

--- a/src/main/resources/assets/storagedrawers/lang/ja_jp.lang
+++ b/src/main/resources/assets/storagedrawers/lang/ja_jp.lang
@@ -173,6 +173,7 @@ storagedrawers.config.integration.tooltip=他のMODとの互換性を設定
 
 storagedrawers.config.integration.enableAE2=Applied Energistics 2 互換を有効化
 storagedrawers.config.integration.enableWaila=WAILA 互換を有効化
+storagedrawers.config.integration.enableTOP=TOP 互換を有効化
 storagedrawers.config.integration.enableThaumcraft=Thaumcraft 互換を有効化
 storagedrawers.config.integration.enableMineTweaker=MineTweaker 互換を有効化
 storagedrawers.config.integration.enableRefinedRelocation=Refined Relocation 互換を有効化

--- a/src/main/resources/assets/storagedrawers/lang/ko_kr.lang
+++ b/src/main/resources/assets/storagedrawers/lang/ko_kr.lang
@@ -106,3 +106,6 @@ storagedrawers.config.integration.tooltip=Configure integration with other mods.
 
 storagedrawers.config.integration.enableAE2=Enable Applied Energistics 2 Integration
 storagedrawers.config.integration.enableWaila=Enable WAILA Integration
+storagedrawers.config.integration.enableTOP=Enable TOP Integration
+storagedrawers.config.integration.enableThaumcraft=Enable Thaumcraft Integration
+storagedrawers.config.integration.enableMineTweaker=Enable MineTweaker Integration

--- a/src/main/resources/assets/storagedrawers/lang/pl_pl.lang
+++ b/src/main/resources/assets/storagedrawers/lang/pl_pl.lang
@@ -103,4 +103,7 @@ storagedrawers.config.integration=Integracja
 storagedrawers.config.integration.tooltip=Konfiguruj integrację z innymi modami.
 
 storagedrawers.config.integration.enableAE2=Włącz integrację z Applied Energistics 2
-storagedrawers.config.integration.enableWaila=Włącz integrację z What Am I Looking At
+storagedrawers.config.integration.enableWaila=Włącz integrację z WAILA
+storagedrawers.config.integration.enableTOP=Włącz integrację z TOP
+storagedrawers.config.integration.enableThaumcraft=Włącz integrację z Thaumcraft
+storagedrawers.config.integration.enableMineTweaker=Włącz integrację z MineTweaker

--- a/src/main/resources/assets/storagedrawers/lang/ru_ru.lang
+++ b/src/main/resources/assets/storagedrawers/lang/ru_ru.lang
@@ -187,6 +187,7 @@ storagedrawers.config.integration.tooltip=Настройки интеграци�
 
 storagedrawers.config.integration.enableAE2=Включить интеграцию с Applied Energistics 2
 storagedrawers.config.integration.enableWaila=Включить интеграцию с WAILA
+storagedrawers.config.integration.enableTOP=Включить интеграцию с TOP
 storagedrawers.config.integration.enableThaumcraft=Включить интеграцию с Thaumcraft
 storagedrawers.config.integration.enableMineTweaker=Включить интеграцию с MineTweaker
 storagedrawers.config.integration.enableRefinedRelocation=Включить интеграцию с Refined Relocation

--- a/src/main/resources/assets/storagedrawers/lang/zh_cn.lang
+++ b/src/main/resources/assets/storagedrawers/lang/zh_cn.lang
@@ -186,6 +186,7 @@ storagedrawers.config.integration.tooltip=设定本模组与其它模组之间�
 
 storagedrawers.config.integration.enableAE2=允许关联应用能源2
 storagedrawers.config.integration.enableWaila=允许关联高亮显示增强(WAILA)
+storagedrawers.config.integration.enableTOP=允许关联TOP
 storagedrawers.config.integration.enableThaumcraft=允许关联神秘时代
 storagedrawers.config.integration.enableMineTweaker=允许关联MineTweaker
 item.storagedrawers.quantifyKey.description=隐藏或显示抽屉内储存的物品数量。

--- a/src/main/resources/assets/storagedrawers/lang/zh_tw.lang
+++ b/src/main/resources/assets/storagedrawers/lang/zh_tw.lang
@@ -156,6 +156,7 @@ storagedrawers.config.integration.tooltip=設定本模組與其它模組之間�
 
 storagedrawers.config.integration.enableAE2=允許關聯應用能源2
 storagedrawers.config.integration.enableWaila=允許關聯WAILA顯示
+storagedrawers.config.integration.enableTOP=允许关联TOP
 storagedrawers.config.integration.enableThaumcraft=允許關聯秘術時代
 storagedrawers.config.integration.enableMineTweaker=允許關聯MineTweaker
 item.storagedrawers.personalKey.description=禁止其他玩家使用抽屜


### PR DESCRIPTION
## Old Behaviour:
If `keep contents on break` config was turned on:
Waila & TOP will display a taped drawer, as long as it has items, even if its not taped
Pick Block (Creative) results in a taped drawer, unlike normal vanilla behaviour, when `ctrl + pick block`.
Wood-Type Trims would always display (in Waila and TOP) as oak trims, and pickblock as that too. Framed trims displayed (in Waila & TOP) as unframed, pickblock gives unframed.

## New Behaviour:
Waila & TOP displays drawers correctly
Pick Block (Creative) results in a normal, untaped and no items contained, drawer, following normal vanilla behaviour, with `ctrl + pick block` giving a taped drawer with the items.
All trims display in Waila and TOP correctly, and pickblock works as expected.

## Other:
Update lang for integration (used existing integration lang as a base)
Added config description for Waila and TOP integration configs.
