### PR TITLE
Fix framing table again

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/attribute/IFrameable.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/attribute/IFrameable.java
@@ -12,7 +12,7 @@ public interface IFrameable {
      * @param matSide ItemStack to use as the decoration on `side`
      * @param matTrim ItemStack to use as the decoration on `trim`
      * @param matFront ItemStack to use as the decoration on `front`
-     * @return The ItemStack to put in the output slot of the Framing Table
+     * @return The ItemStack to put or display in the output slot of the Framing Table
      */
     ItemStack decorate(ItemStack input, ItemStack matSide, ItemStack matTrim, ItemStack matFront);
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/attribute/IFrameable.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/attribute/IFrameable.java
@@ -7,6 +7,7 @@ import net.minecraft.item.ItemStack;
  */
 public interface IFrameable {
     /**
+     * The provided ItemStacks are NOT copies. Unless you want to change the input items in the framing table, DO NOT change the ItemStacks.
      * @param input The input ItemStack of which you can copy relevant NBT from (used for things like copying tile nbt from old framed drawer)
      * @param matSide ItemStack to use as the decoration on `side`
      * @param matTrim ItemStack to use as the decoration on `trim`

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/attribute/IFrameable.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/attribute/IFrameable.java
@@ -7,7 +7,7 @@ import net.minecraft.item.ItemStack;
  */
 public interface IFrameable {
     /**
-     * The provided ItemStacks are NOT copies. Unless you want to change the input items in the framing table, DO NOT change the ItemStacks.
+     * The provided ItemStacks are copies. Do whatever you want with them.
      * @param input The input ItemStack of which you can copy relevant NBT from (used for things like copying tile nbt from old framed drawer)
      * @param matSide ItemStack to use as the decoration on `side`
      * @param matTrim ItemStack to use as the decoration on `trim`

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityFramingRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityFramingRenderer.java
@@ -1,11 +1,8 @@
 package com.jaquadro.minecraft.storagedrawers.client.renderer;
 
-import com.jaquadro.minecraft.storagedrawers.block.BlockDrawersCustom;
+import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.IFrameable;
 import com.jaquadro.minecraft.storagedrawers.block.BlockFramingTable;
-import com.jaquadro.minecraft.storagedrawers.block.BlockTrimCustom;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityFramingTable;
-import com.jaquadro.minecraft.storagedrawers.item.ItemCustomDrawers;
-import com.jaquadro.minecraft.storagedrawers.item.ItemCustomTrim;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
@@ -32,23 +29,20 @@ public class TileEntityFramingRenderer extends TileEntitySpecialRenderer<TileEnt
         if (!state.getValue(BlockFramingTable.RIGHT_SIDE))
             return;
 
-        ItemStack target = tile.getStackInSlot(0);
-        if (!target.isEmpty()) {
-            Block block = Block.getBlockFromItem(target.getItem());
-            IBlockState blockState = block.getStateFromMeta(target.getMetadata());
-            if (block instanceof BlockDrawersCustom) {
-                ItemStack result = ItemCustomDrawers.makeItemStack(blockState, 1, tile.getStackInSlot(1), tile.getStackInSlot(2), tile.getStackInSlot(3));
-                renderSlot(tile, x, y, z, result, 1f, .5f, .25f, -.5f);
-            }
-            else if (block instanceof BlockTrimCustom) {
-                ItemStack result = ItemCustomTrim.makeItemStack(block, 1, tile.getStackInSlot(1), tile.getStackInSlot(2));
-                renderSlot(tile, x, y, z, result, 1f, .5f, .25f, -.5f);
-            }
+        // Get each slot's contents
+        ItemStack input = tile.getStackInSlot(0);
+        ItemStack matSide = tile.getStackInSlot(1);
+        ItemStack matTrim = tile.getStackInSlot(2);
+        ItemStack matFront = tile.getStackInSlot(3);
+
+        if (!input.isEmpty() && input.getItem() instanceof IFrameable && !matSide.isEmpty()) {
+            ItemStack result = ((IFrameable) input.getItem()).decorate(input, matSide, matTrim, matFront);
+            renderSlot(tile, x, y, z, result, 1f, .5f, .25f, -.5f);
         }
 
-        renderSlot(tile, x, y, z, tile.getStackInSlot(1), .575f, .5f + .65f, .15f, .225f - .5f);
-        renderSlot(tile, x, y, z, tile.getStackInSlot(2), .575f, .5f - .65f, .15f, .225f - .5f);
-        renderSlot(tile, x, y, z, tile.getStackInSlot(3), .575f, .5f + .65f, .15f, -.225f - .5f);
+        renderSlot(tile, x, y, z, matSide, .575f, .5f + .65f, .15f, .225f - .5f);
+        renderSlot(tile, x, y, z, matTrim, .575f, .5f - .65f, .15f, .225f - .5f);
+        renderSlot(tile, x, y, z, matFront, .575f, .5f + .65f, .15f, -.225f - .5f);
     }
 
     private void renderSlot (TileEntityFramingTable tileTable, double x, double y, double z, ItemStack item, float scale, float tx, float ty, float tz) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlocks.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModBlocks.java
@@ -101,7 +101,7 @@ public class ModBlocks
             }
             if (config.cache.enableFramingTable) {
                 registry.register(new BlockFramingTable("framingtable", StorageDrawers.MOD_ID + ".framingTable"));
-                GameRegistry.registerTileEntity(TileEntityTrim.class, StorageDrawers.MOD_ID + ":trim");
+                GameRegistry.registerTileEntity(TileEntityFramingTable.class, StorageDrawers.MOD_ID + ":framingtable");
             }
         }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerFramingTable.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerFramingTable.java
@@ -82,7 +82,7 @@ public class ContainerFramingTable extends Container
 
         if (!input.isEmpty() && input.getItem() instanceof IFrameable && !matSide.isEmpty()) {
             craftResult.setInventorySlotContents(0, ((IFrameable) input.getItem())
-                    .decorate(input, matSide, matTrim, matFront));
+                    .decorate(input.copy(), matSide.copy(), matTrim.copy(), matFront.copy()));
             return;
         }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerFramingTable.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/ContainerFramingTable.java
@@ -52,6 +52,7 @@ public class ContainerFramingTable extends Container
         materialSideSlot = addSlotToContainer(new SlotRestricted(tableInventory, 1, MaterialSideX, MaterialSideY));
         materialTrimSlot = addSlotToContainer(new SlotRestricted(tableInventory, 2, MaterialTrimX, MaterialTrimY));
         materialFrontSlot = addSlotToContainer(new SlotRestricted(tableInventory, 3, MaterialFrontX, MaterialFrontY));
+
         outputSlot = addSlotToContainer(new FramingSlotResult(inventory.player, tableInventory, craftResult, new int[] { 0, 1, 2, 3 }, 0, 4, OutputX, OutputY));
 
         playerSlots = new ArrayList<>();
@@ -81,7 +82,7 @@ public class ContainerFramingTable extends Container
 
         if (!input.isEmpty() && input.getItem() instanceof IFrameable && !matSide.isEmpty()) {
             craftResult.setInventorySlotContents(0, ((IFrameable) input.getItem())
-                    .decorate(input.copy(), matSide.copy(), matTrim.copy(), matFront.copy()));
+                    .decorate(input, matSide, matTrim, matFront));
             return;
         }
 


### PR DESCRIPTION
Oops, it registered the TE for the trim twice instead of registering TE for Framing Table.

I've also now clarified that the ItemStacks are copies.

Also fixed the render for the framing table, which rendered the output wrong, and whenever there was an item in the input slot (not taking to account the matSide slot).