### PR TITLE
Fix waila (jade) integration

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
@@ -50,7 +50,7 @@ public class Waila implements IWailaPlugin
 
         @Override
         public ResourceLocation getUid () {
-            return null;
+            return StorageDrawers.rl("wailadrawer");
         }
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
@@ -13,7 +13,7 @@ import snownee.jade.api.ui.IElement;
 import snownee.jade.impl.ui.ItemStackElement;
 
 @WailaPlugin(StorageDrawers.MOD_ID)
-public class Waila implements IWailaPlugin
+public class Waila implements IWailaPlugin, IBlockComponentProvider
 {
     @Override
     public void registerClient (IWailaClientRegistration registration) {
@@ -24,33 +24,29 @@ public class Waila implements IWailaPlugin
         registration.addConfig(StorageDrawers.rl("display.stacklimit"), true);
         registration.addConfig(StorageDrawers.rl("display.status"), true);
 
-        WailaDrawer provider = new WailaDrawer();
-        registration.registerBlockComponent(provider, BlockDrawers.class);
+        registration.registerBlockComponent(this, BlockDrawers.class);
     }
 
-    public static class WailaDrawer implements IBlockComponentProvider
-    {
-        @Override
-        @NotNull
-        public IElement getIcon (BlockAccessor accessor, IPluginConfig config, IElement currentIcon) {
-            return ItemStackElement.of(new ItemStack(accessor.getBlock()));
-        }
+    @Override
+    @NotNull
+    public IElement getIcon (BlockAccessor accessor, IPluginConfig config, IElement currentIcon) {
+        return ItemStackElement.of(new ItemStack(accessor.getBlock()));
+    }
 
-        @Override
-        public void appendTooltip (ITooltip currenttip, BlockAccessor accessor, IPluginConfig config) {
-            BlockEntityDrawers blockEntityDrawers = (BlockEntityDrawers) accessor.getBlockEntity();
+    @Override
+    public void appendTooltip (ITooltip currenttip, BlockAccessor accessor, IPluginConfig config) {
+        BlockEntityDrawers blockEntityDrawers = (BlockEntityDrawers) accessor.getBlockEntity();
 
-            DrawerOverlay overlay = new DrawerOverlay();
-            overlay.showContent = config.get(StorageDrawers.rl("display.content"));
-            overlay.showStackLimit = config.get(StorageDrawers.rl("display.stacklimit"));
-            overlay.showStatus = config.get(StorageDrawers.rl("display.status"));
+        DrawerOverlay overlay = new DrawerOverlay();
+        overlay.showContent = config.get(StorageDrawers.rl("display.content"));
+        overlay.showStackLimit = config.get(StorageDrawers.rl("display.stacklimit"));
+        overlay.showStatus = config.get(StorageDrawers.rl("display.status"));
 
-            currenttip.addAll(overlay.getOverlay(blockEntityDrawers));
-        }
+        currenttip.addAll(overlay.getOverlay(blockEntityDrawers));
+    }
 
-        @Override
-        public ResourceLocation getUid () {
-            return StorageDrawers.rl("wailadrawer");
-        }
+    @Override
+    public ResourceLocation getUid () {
+        return StorageDrawers.rl("wailadrawer");
     }
 }


### PR DESCRIPTION
When using jade, you may get an error when loading minecraft:

```
Error loading plugin at com.jaquadro.minecraft.storagedrawers.integration.Waila
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:209)
	at TRANSFORMER/jade@11.6.3/snownee.jade.impl.HierarchyLookup.register(HierarchyLookup.java:39)
	at TRANSFORMER/jade@11.6.3/snownee.jade.impl.WailaClientRegistration.registerBlockComponent(WailaClientRegistration.java:105)
	at TRANSFORMER/storagedrawers@12.0.2/com.jaquadro.minecraft.storagedrawers.integration.Waila.registerClient(Waila.java:28)
	at TRANSFORMER/jade@11.6.3/snownee.jade.util.CommonProxy.loadComplete(CommonProxy.java:143)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.doCastFilter(EventBus.java:260)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.lambda$addListener$11(EventBus.java:252)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.post(EventBus.java:315)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.post(EventBus.java:296)
	at LAYER PLUGIN/javafmllanguage@1.20.1-47.1.3/net.minecraftforge.fml.javafmlmod.FMLModContainer.acceptEvent(FMLModContainer.java:107)
	at LAYER PLUGIN/fmlcore@1.20.1-47.1.3/net.minecraftforge.fml.ModContainer.lambda$buildTransitionHandler$10(ModContainer.java:124)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```

This pr fixes this