### PR TITLE
Fix occasional crash due to bad removal during iteration

### DIFF
--- a/common/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/ControllerHostData.java
+++ b/common/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/ControllerHostData.java
@@ -48,7 +48,12 @@ public class ControllerHostData extends BlockEntityDataShim
     }
 
     public void validateRemoteNodes (IControlGroup host, Level level) {
-        for (BlockPos pos : nodeMap.keySet()) {
+        // Use iterator directly so that entries can be removed during iteration.
+        Iterator<Map.Entry<BlockPos, INetworked>> iterator = nodeMap.entrySet();
+
+        while (iterator.hasNext()) {
+            BlockPos pos = iterator.next().getKey();
+
             BlockEntity entity = level.getBlockEntity(pos);
             if (entity instanceof INetworked networked) {
                 if (networked.getBoundControlGroup() == host) {
@@ -57,7 +62,7 @@ public class ControllerHostData extends BlockEntityDataShim
                 }
             }
 
-            nodeMap.remove(pos);
+            iterator.remove();
         }
     }
 


### PR DESCRIPTION
This change addresses a bug where the removal a remote node that fails to validate causes the iterator to throw a ConcurrentModifactionException.