### PR TITLE
Fall back to vanilla model store if model isn't present

### DIFF
--- a/common/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/DrawerModelStore.java
+++ b/common/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/DrawerModelStore.java
@@ -4,6 +4,7 @@ import com.jaquadro.minecraft.storagedrawers.ModConstants;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.EnumCompDrawer;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.BlockModelShaper;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelResourceLocation;
@@ -332,7 +333,12 @@ public class DrawerModelStore
         if (loc == null)
             return null;
 
-        return modelStore.getOrDefault(loc.toString(), null);
+        BakedModel storedModel = modelStore.get(loc.toString());
+        if (storedModel == null) {
+            return Minecraft.getInstance().getModelManager().getModel(loc);
+        } else {
+            return storedModel;
+        }
     }
 
     public static BakedModel getModel(String variant) {


### PR DESCRIPTION
## Context

Framed drawers are currently invisible when Storage Drawers is installed alongside ModernFix on Fabric and dynamic resources are enabled. (Tested on 1.20.1, but this probably affects any version.)

This was originally reported to me at https://github.com/embeddedt/ModernFix/issues/538.

## The bug

From debugging, this appears to be caused by the way Storage Drawers uses the Fabric model loading API. The proper way to retrieve extra models used in your custom baked model is to use the `ModelBaker` supplied through the AfterBake event's context. However, it appears Storage Drawers instead uses a custom `DrawerModelStore`, and relies on it being populated by other models having being loaded before the framed drawer is baked. That is not guaranteed if any mod that implements dynamic loading of models and does not load them all during game startup is installed.

## The fix 

This PR attempts to work around the issue by allowing `DrawerModelStore` to fall back to the vanilla model manager to retrieve a missing model. In brief testing it solves the incompatibility with ModernFix, however I don't know if it has other side effects. I would still strongly suggest not to maintain a separate model store if possible; it should be possible to design the model loader to work purely off the provided context. 

## Misc. notes

I have not checked whether this issue also affects Forge, but from a cursory glance at the code, it should not, as the model store is initialized explicitly there by looping over all drawer model locations and adding them before any framed drawer models are built.

I have also not checked whether this affects versions newer than 1.20.1 on Fabric.