### PR TITLE
[1.12.2] Fix sidedness issues with TC & HWYLA integration

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Thaumcraft.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Thaumcraft.java
@@ -184,15 +184,15 @@ public class Thaumcraft extends IntegrationModule
             GlStateManager.disableBlend();
             GlStateManager.enableLighting();
         }
-    }
 
-    private void renderQuad (BufferBuilder tessellator, int x, int y, int w, int h, int r, int g, int b, int a)
-    {
-        tessellator.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR);
-        tessellator.pos(x + 0, y + 0, 0).tex(0, 0).color(r, g, b, a).endVertex();
-        tessellator.pos(x + 0, y + h, 0).tex(0, 1).color(r, g, b, a).endVertex();
-        tessellator.pos(x + w, y + h, 0).tex(1, 1).color(r, g, b, a).endVertex();
-        tessellator.pos(x + w, y + 0, 0).tex(1, 0).color(r, g, b, a).endVertex();
-        Tessellator.getInstance().draw();
+        private void renderQuad (BufferBuilder tessellator, int x, int y, int w, int h, int r, int g, int b, int a)
+        {
+            tessellator.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR);
+            tessellator.pos(x + 0, y + 0, 0).tex(0, 0).color(r, g, b, a).endVertex();
+            tessellator.pos(x + 0, y + h, 0).tex(0, 1).color(r, g, b, a).endVertex();
+            tessellator.pos(x + w, y + h, 0).tex(1, 1).color(r, g, b, a).endVertex();
+            tessellator.pos(x + w, y + 0, 0).tex(1, 0).color(r, g, b, a).endVertex();
+            Tessellator.getInstance().draw();
+        }
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
@@ -17,6 +17,8 @@ import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaDataProvider;
 import mcp.mobius.waila.api.IWailaRegistrar;
+import mcp.mobius.waila.api.impl.ConfigHandler;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
@@ -27,20 +29,16 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.event.FMLInterModComms;
+import net.minecraftforge.fml.relauncher.Side;
 
 import javax.annotation.Nonnull;
-import java.lang.reflect.Method;
 
 import java.util.List;
 
 public class Waila extends IntegrationModule
 {
-    private static Class classConfigHandler;
-
-    private static Method methInstance;
-    private static Method methAddConfig;
-
     @Override
     public String getModID () {
         return "waila";
@@ -48,11 +46,6 @@ public class Waila extends IntegrationModule
 
     @Override
     public void init () throws Throwable {
-        classConfigHandler = Class.forName("mcp.mobius.waila.api.impl.ConfigHandler");
-
-        methInstance = classConfigHandler.getMethod("instance");
-        methAddConfig = classConfigHandler.getMethod("addConfig", String.class, String.class, String.class);
-
         FMLInterModComms.sendMessage("waila", "register", StorageDrawers.SOURCE_PATH + "integration.Waila.registerProvider");
     }
 
@@ -66,16 +59,10 @@ public class Waila extends IntegrationModule
         registrar.registerBodyProvider(provider, BlockDrawers.class);
         registrar.registerStackProvider(provider, BlockDrawers.class);
 
-        try {
-            Object configHandler = methInstance.invoke(null);
-
-            methAddConfig.invoke(configHandler, StorageDrawers.MOD_NAME, "display.content", I18n.format("storageDrawers.waila.config.displayContents"), true);
-            methAddConfig.invoke(configHandler, StorageDrawers.MOD_NAME, "display.stacklimit", I18n.format("storageDrawers.waila.config.displayStackLimit"), true);
-            methAddConfig.invoke(configHandler, StorageDrawers.MOD_NAME, "display.status", I18n.format("storageDrawers.waila.config.displayStatus"), true);
-        }
-        catch (Exception e) {
-            // Oh well, we couldn't hook the waila config
-            StorageDrawers.log.error("Failed to hook the Waila Config. Could not add in custom Storage Drawers related configs.");
+        if (FMLCommonHandler.instance().getSide() == Side.CLIENT) {
+            ConfigHandler.instance().addConfig(StorageDrawers.MOD_NAME, "display.content", I18n.format("storageDrawers.waila.config.displayContents"), true);
+            ConfigHandler.instance().addConfig(StorageDrawers.MOD_NAME, "display.stacklimit", I18n.format("storageDrawers.waila.config.displayStackLimit"), true);
+            ConfigHandler.instance().addConfig(StorageDrawers.MOD_NAME, "display.status", I18n.format("storageDrawers.waila.config.displayStatus"), true);
         }
     }
 


### PR DESCRIPTION
This fixes client-only classes being class-loaded on a dedicated server. Functionally, there is no difference as the two integration modules are technically only handled client-side, but now the modules don't error when being registered on the dedicated server.
Thaumcraft error:
```
[Server thread/INFO] [chameleon]: Could not load integration module: com.jaquadro.minecraft.storagedrawers.integration.Thaumcraft
```
HWYLA/Waila error:
```
[Server thread/INFO] [Waila]: Registering plugin at com.jaquadro.minecraft.storagedrawers.integration.Waila
[Server thread/ERROR] [Waila]: Error registering wrapped plugin from storagedrawers at com.jaquadro.minecraft.storagedrawers.integration.Waila.registerProvider
```
Removes reflection usage, as it is not needed to access `ConfigHandler`.
Discovered in CleanroomMC/Cleanroom#349, as there are visible errors that arise from the bug in a Cleanroom environment.