### PR TITLE
[1.20] Fixes Fabric Void Upgrade

### DIFF
--- a/common/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityController.java
+++ b/common/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityController.java
@@ -707,7 +707,7 @@ public class BlockEntityController extends BaseBlockEntity implements IDrawerGro
         }
     }
 
-    protected IDrawerGroup getGroupForDrawerSlot (int drawerSlot) {
+    public IDrawerGroup getGroupForDrawerSlot(int drawerSlot) {
         if (drawerSlot < 0 || drawerSlot >= drawerSlotList.size())
             return null;
 

--- a/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/DrawerStackStorage.java
+++ b/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/inventory/DrawerStackStorage.java
@@ -2,6 +2,10 @@ package com.jaquadro.minecraft.storagedrawers.inventory;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributes;
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityController;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntitySlave;
 import com.jaquadro.minecraft.storagedrawers.capabilities.Capabilities;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.item.base.SingleStackStorage;
@@ -43,17 +47,72 @@ public class DrawerStackStorage extends SingleStackStorage
         return storage.getDrawer(slot).getMaxCapacity(itemVariant.toStack());
     }
 
+    /**
+     * Gets drawer attributes from a drawer group, trying capability first, then direct access
+     */
+    private IDrawerAttributes getDrawerAttributes(IDrawerGroup group) {
+        if (group == null) return null;
+        
+        // Try capability first
+        IDrawerAttributes attr = group.getCapability(Capabilities.DRAWER_ATTRIBUTES);
+        
+        // If that fails and it's a BlockEntityDrawers, get attributes directly
+        if (attr == null && group instanceof BlockEntityDrawers) {
+            attr = ((BlockEntityDrawers) group).getDrawerAttributes();
+        }
+        
+        return attr;
+    }
+    
+    /**
+     * Checks if a drawer from a controller has void attribute
+     */
+    private boolean checkControllerVoid(BlockEntityController controller) {
+        if (controller == null) return false;
+        
+        IDrawer drawer = storage.getDrawer(slot);
+        if (drawer == null || !drawer.isEnabled()) return false;
+        
+        // Get the underlying drawer group that this drawer belongs to
+        IDrawerGroup drawerGroup = controller.getGroupForDrawerSlot(slot);
+        if (drawerGroup == null) return false;
+        
+        // Get attributes and check void
+        IDrawerAttributes attrs = getDrawerAttributes(drawerGroup);
+        return attrs != null && attrs.isVoid();
+    }
+    
     @Override
     public long insert (ItemVariant insertedVariant, long maxAmount, TransactionContext transaction) {
+        long inserted = super.insert(insertedVariant, maxAmount, transaction);
+        
+        if (inserted < maxAmount) {
+            boolean isVoid;
+
+            if (storage.group instanceof BlockEntityController) {
+                // Handle controller case
+                isVoid = checkControllerVoid((BlockEntityController) storage.group);
+            } 
+            else if (storage.group instanceof BlockEntitySlave) {
+                // Handle slave case by getting its controller
+                BlockEntityController controller =
+                    ((BlockEntitySlave) storage.group).getController();
+                isVoid = checkControllerVoid(controller);
+            } 
+            else {
+                // Handle normal drawer case
+                IDrawerAttributes attr = getDrawerAttributes(storage.group);
+                isVoid = attr != null && attr.isVoid();
+            }
+            
+            // If we found the void attribute, accept the full amount
+            if (isVoid) {
+                inserted = maxAmount;
+            }
+        }
+    
         if (!storage.getDrawer(slot).canItemBeStored(insertedVariant.toStack()))
             return 0;
-
-        long inserted = super.insert(insertedVariant, maxAmount, transaction);
-        if (inserted < maxAmount) {
-            IDrawerAttributes attr = storage.group.getCapability(Capabilities.DRAWER_ATTRIBUTES);
-            if (attr != null && attr.isVoid())
-                inserted = maxAmount;
-        }
 
         return inserted;
     }


### PR DESCRIPTION
Fixes fabric void upgrade not being honored when items are inserted into Controller and Slave from an external inventory.

Original behavior resulted in items refusing to be inserted into slaves and controllers even with a matching void drawer on the network.