### PR TITLE
1.21.4 Fix issue where the framing table would remove contents of drawers.

### DIFF
--- a/common/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityFramingTable.java
+++ b/common/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockEntityFramingTable.java
@@ -327,7 +327,7 @@ public class BlockEntityFramingTable extends BaseBlockEntity implements Nameable
                         source.remove(ModDataComponents.FRAME_DATA.get());
 
                         int count = stack.getCount();
-                        entity.inputStack = source.copyWithCount(count);
+                        entity.inputStack = stack.transmuteCopy(source.getItem());
 
                         entity.materialData.setSide(fb.supportsFrameMaterial(FrameMaterial.SIDE) ? data.side().copyWithCount(count) : ItemStack.EMPTY);
                         entity.materialData.setTrim(fb.supportsFrameMaterial(FrameMaterial.TRIM) ? data.trim().copyWithCount(count) : ItemStack.EMPTY);

--- a/common/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/util/FrameHelper.java
+++ b/common/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/util/FrameHelper.java
@@ -35,7 +35,7 @@ public class FrameHelper
         if (resultBlock.supportsFrameMaterial(FrameMaterial.FRONT))
             data.setFront(matFront.copyWithCount(1));
 
-        ItemStack stack = new ItemStack((Block)resultBlock, source.getCount());
+        ItemStack stack = source.transmuteCopy(((Block) resultBlock).asItem());
         stack.set(ModDataComponents.FRAME_DATA.get(), new FrameData(data));
 
         return stack;


### PR DESCRIPTION
Uses `transmuteCopy` instead of `copyWithCount` in order to preserve components while still changing the base item.

Fixes #1213 