### PR TITLE
[1.21.4 FABRIC] Add missing registerForBlockEntity call for 2-Tier Compacting Drawers.

### DIFF
--- a/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/capabilities/PlatformCapabilities.java
+++ b/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/capabilities/PlatformCapabilities.java
@@ -50,6 +50,7 @@ public class PlatformCapabilities
         ItemStorage.SIDED.registerForBlockEntity((entity, dir) -> DrawerStorageImpl.of(entity), ModBlockEntities.STANDARD_DRAWERS_1.get());
         ItemStorage.SIDED.registerForBlockEntity((entity, dir) -> DrawerStorageImpl.of(entity), ModBlockEntities.STANDARD_DRAWERS_2.get());
         ItemStorage.SIDED.registerForBlockEntity((entity, dir) -> DrawerStorageImpl.of(entity), ModBlockEntities.STANDARD_DRAWERS_4.get());
+        ItemStorage.SIDED.registerForBlockEntity((entity, dir) -> DrawerStorageImpl.of(entity), ModBlockEntities.FRACTIONAL_DRAWERS_2.get());
         ItemStorage.SIDED.registerForBlockEntity((entity, dir) -> DrawerStorageImpl.of(entity), ModBlockEntities.FRACTIONAL_DRAWERS_3.get());
         ItemStorage.SIDED.registerForBlockEntity((entity, dir) -> DrawerStorageImpl.of(entity), ModBlockEntities.CONTROLLER.get());
         ItemStorage.SIDED.registerForBlockEntity((entity, dir) -> DrawerStorageImpl.of(entity), ModBlockEntities.CONTROLLER_IO.get());


### PR DESCRIPTION
Allows hoppers (and other blocks) to correctly insert into 2-Tier Compacting Drawers.