### PR TITLE
Fix remote group upgrade item name when bound

### DIFF
--- a/common/src/main/resources/assets/storagedrawers/lang/en_us.json
+++ b/common/src/main/resources/assets/storagedrawers/lang/en_us.json
@@ -87,7 +87,7 @@
     "item.storagedrawers.remote_group_upgrade": "Remote Group Upgrade",
     "item.storagedrawers.remote_group_upgrade.desc": "Lets connected drawer group remotely connect to controller",
     "item.storagedrawers.remote_group_upgrade.bound": "Use on controller to bind upgrade",
-    "item.storagedrawers.remote_group_upgrade_bound": "Remote Upgrade",
+    "item.storagedrawers.remote_group_upgrade_bound": "Remote Group Upgrade",
     "item.storagedrawers.remote_group_upgrade_bound.desc": "Lets connected drawer group remotely connect to controller. Can be used on upgraded drawer to re-bind it",
     "item.storagedrawers.remote_group_upgrade_bound.bound": "Bound to controller [%d, %d, %d]",
     "item.storagedrawers.upgrade_template": "Upgrade Template",

--- a/common/src/main/resources/assets/storagedrawers/lang/es_es.json
+++ b/common/src/main/resources/assets/storagedrawers/lang/es_es.json
@@ -83,7 +83,7 @@
     "item.storagedrawers.remote_group_upgrade": "Mejora de Grupo Remoto",
     "item.storagedrawers.remote_group_upgrade.desc": "Permite que el grupo de cajones conectado se conecte de forma remota al controlador",
     "item.storagedrawers.remote_group_upgrade.bound": "Usar en el controlador para enlazar la mejora",
-    "item.storagedrawers.remote_group_upgrade_bound": "Mejora remota",
+    "item.storagedrawers.remote_group_upgrade_bound": "Mejora de Grupo Remoto",
     "item.storagedrawers.remote_group_upgrade_bound.desc": "Permite conectarse de forma remota al grupo de cajones conectados al controlador. Se puede usar en el cajón actualizado para volver a enlazarlo",
     "item.storagedrawers.remote_group_upgrade_bound.bound": "Vinculado al controlador [%d, %d, %d]",
     "item.storagedrawers.upgrade_template": "Mejorar plantilla",

--- a/common/src/main/resources/assets/storagedrawers/lang/ru_ru.json
+++ b/common/src/main/resources/assets/storagedrawers/lang/ru_ru.json
@@ -78,7 +78,7 @@
     "item.storagedrawers.remote_group_upgrade": "Обновление удаленной группы",
     "item.storagedrawers.remote_group_upgrade.desc": "Позволяет подключенной группе ящиков удаленно подключаться к контроллеру",
     "item.storagedrawers.remote_group_upgrade.bound": "Используйте на контроллере для привязки обновления",
-    "item.storagedrawers.remote_group_upgrade_bound": "Обновление удаленного доступа (группы)",
+    "item.storagedrawers.remote_group_upgrade_bound": "Обновление удаленной группы (связанное)",
     "item.storagedrawers.remote_group_upgrade_bound.desc": "Позволяет подключенной группе ящиков удаленно подключаться к контроллеру. Может использоваться на обновленном ящике для его повторной привязки",
     "item.storagedrawers.remote_group_upgrade_bound.bound": "Привязка к контроллеру [%d, %d, %d]",
     "item.storagedrawers.upgrade_template": "Обновление шаблона",

--- a/common/src/main/resources/assets/storagedrawers/lang/zh_cn.json
+++ b/common/src/main/resources/assets/storagedrawers/lang/zh_cn.json
@@ -83,7 +83,7 @@
     "item.storagedrawers.remote_group_upgrade": "远程抽屉组升级",
     "item.storagedrawers.remote_group_upgrade.desc": "让连接的抽屉组远程连接到控制器",
     "item.storagedrawers.remote_group_upgrade.bound": "对控制器使用来绑定升级",
-    "item.storagedrawers.remote_group_upgrade_bound": "远程升级",
+    "item.storagedrawers.remote_group_upgrade_bound": "远程抽屉组升级",
     "item.storagedrawers.remote_group_upgrade_bound.desc": "让连接的抽屉组远程连接到控制器。可以在升级抽屉上使用来重新绑定它",
     "item.storagedrawers.remote_group_upgrade_bound.bound": "绑定到控制器 [%d， %d， %d]",
     "item.storagedrawers.upgrade_template": "升级模板",


### PR DESCRIPTION
This fixes a small bug from the spreadsheet. It's for 1.21.1, but you can port it to the other versions.

This also systematically fixes the translated es_es, ru_ru and zh_cn strings to be in-line with their other translations.
I suspect translators might have been confused by this issue in en_us.

The other language files are lacking these translations or were already correctly translated.