### PR TITLE
Fix remote group upgrade item name when bound

### DIFF
--- a/common/src/main/resources/assets/storagedrawers/lang/es_es.json
+++ b/common/src/main/resources/assets/storagedrawers/lang/es_es.json
@@ -83,7 +83,7 @@
     "item.storagedrawers.remote_group_upgrade": "Mejora de Grupo Remoto",
     "item.storagedrawers.remote_group_upgrade.desc": "Permite que el grupo de cajones conectado se conecte de forma remota al controlador",
     "item.storagedrawers.remote_group_upgrade.bound": "Usar en el controlador para enlazar la mejora",
-    "item.storagedrawers.remote_group_upgrade_bound": "Mejora de Grupo remota",
+    "item.storagedrawers.remote_group_upgrade_bound": "Mejora de Grupo Remoto",
     "item.storagedrawers.remote_group_upgrade_bound.desc": "Permite conectarse de forma remota al grupo de cajones conectados al controlador. Se puede usar en el cajón actualizado para volver a enlazarlo",
     "item.storagedrawers.remote_group_upgrade_bound.bound": "Vinculado al controlador [%d, %d, %d]",
     "item.storagedrawers.upgrade_template": "Mejorar plantilla",

--- a/common/src/main/resources/assets/storagedrawers/lang/ru_ru.json
+++ b/common/src/main/resources/assets/storagedrawers/lang/ru_ru.json
@@ -78,7 +78,7 @@
     "item.storagedrawers.remote_group_upgrade": "Обновление удаленной группы",
     "item.storagedrawers.remote_group_upgrade.desc": "Позволяет подключенной группе ящиков удаленно подключаться к контроллеру",
     "item.storagedrawers.remote_group_upgrade.bound": "Используйте на контроллере для привязки обновления",
-    "item.storagedrawers.remote_group_upgrade_bound": "Обновление удаленного доступа (группы)",
+    "item.storagedrawers.remote_group_upgrade_bound": "Обновление удаленной группы (связанное)",
     "item.storagedrawers.remote_group_upgrade_bound.desc": "Позволяет подключенной группе ящиков удаленно подключаться к контроллеру. Может использоваться на обновленном ящике для его повторной привязки",
     "item.storagedrawers.remote_group_upgrade_bound.bound": "Привязка к контроллеру [%d, %d, %d]",
     "item.storagedrawers.upgrade_template": "Обновление шаблона",


### PR DESCRIPTION
For both 1.20.1 ru_ru and es_es, as these were missing/incorrect in the previous merge/backport.