### PR TITLE
Add WAILA support for Jade fabric version

### DIFF
--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     modImplementation("net.fabricmc.fabric-api:fabric-api:${Versions.fabric}")
 
     modCompileOnly("fuzs.forgeconfigapiport:forgeconfigapiport-fabric:21.9.6")
-
+    modCompileOnly("curse.maven:jade-324717:7132429")
     //modCompileOnlyApi("mezz.jei:jei-${Versions.minecraft}-fabric-api:19.8.2.99")
     //modRuntimeOnly("mezz.jei:jei-${Versions.minecraft}-fabric:19.8.2.99")
 }

--- a/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
+++ b/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
@@ -9,6 +9,7 @@ import com.texelsaurus.minecraft.chameleon.api.ChameleonInit;
 import com.texelsaurus.minecraft.chameleon.service.ChameleonConfig;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.minecraft.resources.ResourceLocation;
 
 public class StorageDrawers implements ModInitializer
 {
@@ -47,5 +48,9 @@ public class StorageDrawers implements ModInitializer
         LocalIntegrationRegistry.initialize();
         LocalIntegrationRegistry.instance().init();
         LocalIntegrationRegistry.instance().postInit();
+    }
+
+    public static ResourceLocation rl(String path) {
+        return ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, path);
     }
 }

--- a/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/DrawerOverlay.java
+++ b/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/DrawerOverlay.java
@@ -1,0 +1,122 @@
+package com.jaquadro.minecraft.storagedrawers.integration;
+
+import com.jaquadro.minecraft.storagedrawers.api.storage.*;
+import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.capabilities.Capabilities;
+import com.jaquadro.minecraft.storagedrawers.config.ModCommonConfig;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DrawerOverlay {
+    public boolean showContent = true;
+    public boolean showStackLimit = true;
+    public boolean showStatus = true;
+    public boolean showStackRemainder;
+    public boolean respectQuantifyKey;
+
+    public DrawerOverlay() {
+        showStackRemainder = ModCommonConfig.INSTANCE.INTEGRATION.waila.stackRemainder.get();
+        respectQuantifyKey = ModCommonConfig.INSTANCE.INTEGRATION.waila.respectQuantifyKey.get();
+    }
+
+    public List<Component> getOverlay(final BlockEntityDrawers tile) {
+        final List<Component> result = new ArrayList<>();
+
+        IDrawerAttributes attr = tile.getCapability(Capabilities.DRAWER_ATTRIBUTES);
+        if (attr == null)
+            attr = EmptyDrawerAttributes.EMPTY;
+
+        // addContent(result, tile, attr);
+        addStackLimit(result, tile, attr);
+        addStatus(result, tile, attr);
+
+        return result;
+    }
+
+    private void addContent(final List<Component> result, final BlockEntityDrawers tile, final IDrawerAttributes attr) {
+        if (!this.showContent || attr.isConcealed()) return;
+        final boolean showCounts = !this.respectQuantifyKey || attr.isShowingQuantity();
+
+        final IDrawerGroup group = tile.getGroup();
+        for (int i = 0; i < group.getDrawerCount(); i++) {
+            final IDrawer drawer = group.getDrawer(i);
+            if (!drawer.isEnabled())
+                continue;
+
+            Component name = Component.translatable("tooltip.storagedrawers.waila.empty");
+
+            final ItemStack stack = drawer.getStoredItemPrototype();
+            if (!stack.isEmpty()) {
+                final MutableComponent stackName = Component.translatable("").append(stack.getDisplayName());
+
+                if (showCounts) {
+                    if (drawer.getStoredItemCount() == Integer.MAX_VALUE) {
+                        name = stackName.append("[\u221E]");
+                    } else if (drawer instanceof IFractionalDrawer && ((IFractionalDrawer) drawer).getConversionRate() > 1) {
+                        final String text = ((i == 0) ? " [" : " [+") + ((IFractionalDrawer) drawer).getStoredItemRemainder() + "]";
+                        name = stackName.append(text);
+                    } else if (this.showStackRemainder) {
+                        final int stacks = drawer.getStoredItemCount() / drawer.getStoredItemStackSize();
+                        final int remainder = drawer.getStoredItemCount() - (stacks * drawer.getStoredItemStackSize());
+                        if (stacks > 0 && remainder > 0)
+                            name = stackName.append(" [" + stacks + "x" + drawer.getStoredItemStackSize() + " + " + remainder + "]");
+                        else if (stacks > 0)
+                            name = stackName.append(" [" + stacks + "x" + drawer.getStoredItemStackSize() + "]");
+                        else
+                            name = stackName.append(" [" + remainder + "]");
+                    } else
+                        name = stackName.append(" [" + drawer.getStoredItemCount() + "]");
+                } else {
+                    name = stackName;
+                }
+            }
+            result.add(Component.translatable("tooltip.storagedrawers.waila.drawer", i + 1, name));
+        }
+
+    }
+
+    private void addStackLimit(List<Component> result, BlockEntityDrawers tile, IDrawerAttributes attr) {
+        if (!this.showStackLimit) return;
+
+        if (attr.isUnlimitedStorage() || tile.getDrawerAttributes().isUnlimitedVending())
+            result.add(Component.translatable("tooltip.storagedrawers.waila.nolimit"));
+        else {
+            int multiplier = tile.upgrades().getStorageMultiplier();
+            int limit = tile.getEffectiveDrawerCapacity();
+            try {
+                limit = Math.multiplyExact(limit, multiplier);
+            } catch (ArithmeticException e) {
+                limit = Integer.MAX_VALUE / 64;
+            }
+
+            result.add(Component.translatable("tooltip.storagedrawers.waila.limit", limit, multiplier));
+        }
+    }
+
+    private void addStatus(List<Component> result, BlockEntityDrawers tile, IDrawerAttributes attr) {
+        if (!this.showStatus) return;
+
+        List<MutableComponent> attribs = new ArrayList<>();
+        if (attr.isItemLocked(LockAttribute.LOCK_POPULATED))
+            attribs.add(Component.translatable("tooltip.storagedrawers.waila.locked"));
+        if (attr.isVoid())
+            attribs.add(Component.translatable("tooltip.storagedrawers.waila.void"));
+        if (attr.isBalancedFill())
+            attribs.add(Component.translatable("tooltip.storagedrawers.waila.balanced"));
+        if (tile.getOwner() != null)
+            attribs.add(Component.translatable("tooltip.storagedrawers.waila.protected"));
+        if (attr.isMagnet())
+            attribs.add(Component.translatable("tooltip.storagedrawers.waila.magnetic"));
+        if (attr.isSuspended())
+            attribs.add(Component.translatable("tooltip.storagedrawers.waila.suspended"));
+
+        if (!attribs.isEmpty())
+            result.add(attribs.stream().reduce((a, b) ->
+                    a.append(Component.literal(", ")).append(b)).get());
+    }
+}

--- a/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
+++ b/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/Waila.java
@@ -1,0 +1,59 @@
+package com.jaquadro.minecraft.storagedrawers.integration;
+
+import com.jaquadro.minecraft.storagedrawers.ModConstants;
+import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockEntityDrawers;
+import com.jaquadro.minecraft.storagedrawers.config.ModClientConfig;
+import com.jaquadro.minecraft.storagedrawers.config.ModCommonConfig;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import snownee.jade.api.*;
+import snownee.jade.api.config.IPluginConfig;
+import snownee.jade.api.ui.Element;
+import snownee.jade.impl.ui.ItemStackElement;
+
+@WailaPlugin(ModConstants.MOD_ID)
+public class Waila implements IWailaPlugin
+{
+    @Override
+    public void registerClient (IWailaClientRegistration registration) {
+        if (!ModCommonConfig.INSTANCE.INTEGRATION.waila.enable.get()
+            || !ModClientConfig.INSTANCE.INTEGRATION.enableWaila.get())
+            return;
+
+        registration.addConfig(StorageDrawers.rl("display.content"), true);
+        registration.addConfig(StorageDrawers.rl("display.stacklimit"), true);
+        registration.addConfig(StorageDrawers.rl("display.status"), true);
+
+        WailaDrawer provider = new WailaDrawer();
+        registration.registerBlockComponent(provider, BlockDrawers.class);
+    }
+
+    public static class WailaDrawer implements IBlockComponentProvider
+    {
+        @Override
+        public @Nullable Element getIcon (BlockAccessor accessor, IPluginConfig config, Element currentIcon) {
+            return ItemStackElement.of(new ItemStack(accessor.getBlock()));
+        }
+
+        @Override
+        public void appendTooltip (ITooltip currenttip, BlockAccessor accessor, IPluginConfig config) {
+            BlockEntityDrawers blockEntityDrawers = (BlockEntityDrawers) accessor.getBlockEntity();
+
+            DrawerOverlay overlay = new DrawerOverlay();
+            overlay.showContent = config.get(StorageDrawers.rl("display.content"));
+            overlay.showStackLimit = config.get(StorageDrawers.rl("display.stacklimit"));
+            overlay.showStatus = config.get(StorageDrawers.rl("display.status"));
+
+            currenttip.addAll(overlay.getOverlay(blockEntityDrawers));
+        }
+
+        @Override
+        public ResourceLocation getUid () {
+            return ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "main");
+        }
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -1,33 +1,38 @@
 {
-    "schemaVersion": 1,
-    "id": "${mod_id}",
-    "name": "${mod_name}",
-    "version": "${mod_version}",
-    "environment": "*",
-    "icon": "icon.png",
-    "authors": ["${mod_authors}"],
-    "license": "${mod_license}",
-    "contact": {
-        "homepage": "https://www.curseforge.com/minecraft/mc-mods/storage-drawers",
-        "sources": "https://github.com/jaquadro/StorageDrawers",
-        "issues": "https://github.com/jaquadro/StorageDrawers/issues"
-    },
-    "description": "${mod_description}",
-    "accessWidener": "storagedrawers.fabric.accesswidener",
-    "entrypoints": {
-        "main": [
-            "com.jaquadro.minecraft.storagedrawers.StorageDrawers"
-        ],
-        "client": [
-            "com.jaquadro.minecraft.storagedrawers.StorageDrawersClient"
-        ]
-    },
-    "depends": {
-        "fabricloader": ">=${fabric_loader_min}",
-        "fabric-api": "*",
-        "java": ">=${java_version}",
-        "minecraft": ">=${minecraft_version_lower} <${minecraft_version_upper}"
-    },
-    "custom": {},
-    "mixins": []
+  "schemaVersion": 1,
+  "id": "${mod_id}",
+  "name": "${mod_name}",
+  "version": "${mod_version}",
+  "environment": "*",
+  "icon": "icon.png",
+  "authors": [
+    "${mod_authors}"
+  ],
+  "license": "${mod_license}",
+  "contact": {
+    "homepage": "https://www.curseforge.com/minecraft/mc-mods/storage-drawers",
+    "sources": "https://github.com/jaquadro/StorageDrawers",
+    "issues": "https://github.com/jaquadro/StorageDrawers/issues"
+  },
+  "description": "${mod_description}",
+  "accessWidener": "storagedrawers.fabric.accesswidener",
+  "entrypoints": {
+    "main": [
+      "com.jaquadro.minecraft.storagedrawers.StorageDrawers"
+    ],
+    "client": [
+      "com.jaquadro.minecraft.storagedrawers.StorageDrawersClient"
+    ],
+    "jade": [
+      "com.jaquadro.minecraft.storagedrawers.integration.Waila"
+    ]
+  },
+  "depends": {
+    "fabricloader": ">=${fabric_loader_min}",
+    "fabric-api": "*",
+    "java": ">=${java_version}",
+    "minecraft": ">=${minecraft_version_lower} <${minecraft_version_upper}"
+  },
+  "custom": {},
+  "mixins": []
 }


### PR DESCRIPTION
Jade has a fabric version, and WAILA support works just the same as
the neoforged version.

Tested on 1.21.10 fabric server and client.
