### PR TITLE
Small optimization in bindCoord to avoid useless revalidation

### DIFF
--- a/common/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/ControllerData.java
+++ b/common/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/tiledata/ControllerData.java
@@ -65,6 +65,9 @@ public class ControllerData extends BlockEntityDataShim
         if (ModCommonConfig.INSTANCE.GENERAL.debugTrace.get())
             ModServices.log.info("ControllerData [{}] bind coord [{}]", controllerCoord, pos);
 
+        if (controllerCoord == null && pos == null)
+            return false;
+        
         if (controllerCoord == null || !controllerCoord.equals(pos)) {
             controllerCoord = pos;
             return true;


### PR DESCRIPTION
bindCoord currently says the binding changed even when it's null and being set to null.

This fixes it to not report a change when both current coordinate, and binding coordinate, are null.