### PR TITLE
Change block render layer from CUTOUT_MIPPED to TRANSLUCENT

### DIFF
--- a/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawersClient.java
+++ b/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawersClient.java
@@ -37,7 +37,7 @@ public class StorageDrawersClient implements ClientModInitializer
         ModBlocks.getDrawers().forEach(block ->
             BlockRenderLayerMap.putBlock(block, ChunkSectionLayer.CUTOUT_MIPPED));
         ModBlocks.getFramedBlocks().forEach(block ->
-            BlockRenderLayerMap.putBlock((Block)block, ChunkSectionLayer.CUTOUT_MIPPED));
+            BlockRenderLayerMap.putBlock((Block)block, ChunkSectionLayer.TRANSLUCENT));
 
         MenuScreens.register(ModContainers.DRAWER_CONTAINER_1.get(), DrawerScreen.Slot1::new);
         MenuScreens.register(ModContainers.DRAWER_CONTAINER_2.get(), DrawerScreen.Slot2::new);


### PR DESCRIPTION
CUTOUT_MIPPED works correctly with a plain Fabric server, but breaks when Sodium is added.

TRANSLUCENT supports the whole ALPHA range and should work properly with framed texture overlays.
This would match the rendering type defined in the framed block model file.

This should fix issue with #1282