### PR TITLE
Fixes incompatibility with Continuity

### DIFF
--- a/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawersClient.java
+++ b/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawersClient.java
@@ -3,6 +3,7 @@ package com.jaquadro.minecraft.storagedrawers;
 import com.jaquadro.minecraft.storagedrawers.client.gui.ClientDetachedDrawerTooltip;
 import com.jaquadro.minecraft.storagedrawers.client.gui.ClientKeyringTooltip;
 import com.jaquadro.minecraft.storagedrawers.client.model.ModelLoadPlugin;
+import com.jaquadro.minecraft.storagedrawers.client.model.PlatformDecoratedModel;
 import com.jaquadro.minecraft.storagedrawers.client.renderer.BlockEntityDrawersRenderer;
 import com.jaquadro.minecraft.storagedrawers.client.renderer.BlockEntityFramingRenderer;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlockEntities;
@@ -21,6 +22,7 @@ import net.fabricmc.fabric.api.client.rendering.v1.TooltipComponentCallback;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
+import net.minecraft.client.renderer.item.ItemModels;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.level.block.Block;
 
@@ -31,6 +33,11 @@ public class StorageDrawersClient implements ClientModInitializer
     public void onInitializeClient () {
         ModBlockEntities.DRAWER_TYPES.forEach(ro -> BlockEntityRenderers.register(ro.get(), BlockEntityDrawersRenderer::new));
         BlockEntityRenderers.register(ModBlockEntities.FRAMING_TABLE.get(), BlockEntityFramingRenderer::new);
+
+        // Register model mapper on initialization
+        ItemModels.ID_MAPPER.put(
+            ModConstants.loc("framed_block"), PlatformDecoratedModel.PlatformDecoratedItemModel.Unbaked.MAP_CODEC
+        );
 
         ModelLoadingPlugin.register(new ModelLoadPlugin());
 

--- a/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/ModelLoadPlugin.java
+++ b/fabric/src/main/java/com/jaquadro/minecraft/storagedrawers/client/model/ModelLoadPlugin.java
@@ -1,19 +1,11 @@
 package com.jaquadro.minecraft.storagedrawers.client.model;
 
 import com.jaquadro.minecraft.storagedrawers.ModConstants;
-import com.jaquadro.minecraft.storagedrawers.block.tile.modelprops.DrawerModelProperties;
-import com.jaquadro.minecraft.storagedrawers.block.tile.modelprops.FramedModelProperties;
-import com.jaquadro.minecraft.storagedrawers.client.model.context.DrawerModelContext;
-import com.jaquadro.minecraft.storagedrawers.client.model.context.FramedModelContext;
-import com.jaquadro.minecraft.storagedrawers.client.model.decorator.CombinedModelDecorator;
-import com.jaquadro.minecraft.storagedrawers.client.model.decorator.DrawerModelDecorator;
-import com.jaquadro.minecraft.storagedrawers.client.model.decorator.MaterialModelDecorator;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
 import net.minecraft.client.renderer.block.model.BlockStateModel;
-import net.minecraft.client.renderer.item.ItemModels;
 import net.minecraft.client.resources.model.ModelBaker;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
@@ -95,10 +87,6 @@ public class ModelLoadPlugin implements ModelLoadingPlugin
 
     @Override
     public void initialize (Context pluginContext) {
-        ItemModels.ID_MAPPER.put(
-            ModConstants.loc("framed_block"), PlatformDecoratedModel.PlatformDecoratedItemModel.Unbaked.MAP_CODEC
-        );
-
         DrawerModelGeometry.loadGeometryData();
         pluginContext.modifyBlockModelOnLoad().register((original, context) -> {
             if (context.state() == null)


### PR DESCRIPTION
The `framed_block` item model was registered too late, and it prevents Continuity from knowing about the custom item model.

It resulted in framed blocks being rendered as missing texture.